### PR TITLE
chore(ci): add Dependabot with grouped, cooldown-gated auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # Collapse the weekly minor/patch churn into a single rolling PR
+    # instead of one PR per package.
+    groups:
+      npm-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    # Supply-chain delay: don't propose an update until the new version
+    # has been published for at least 3 days. Mitigates auto-merging a
+    # freshly-published malicious release.
+    cooldown:
+      semver-minor-days: 3
+      semver-patch-days: 3
+    # Majors always require a human; never auto-bumped or auto-merged.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,35 @@
+name: Dependabot auto-merge
+
+# Auto-enable GitHub auto-merge ("--auto") for Dependabot patch/minor PRs.
+# The PR still only merges once branch protection's required checks
+# (the "Test & Coverage" job) pass. Gated to the trusted dependabot[bot] actor
+# AND author; on: pull_request (not pull_request_target); never runs or
+# trusts third-party PR code.
+on: pull_request
+
+concurrency:
+  group: dependabot-automerge-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  dependabot:
+    name: Auto-merge Dependabot patch/minor PRs
+    runs-on: ubuntu-latest
+    # Verify both the triggering actor and the PR author to avoid actor spoofing.
+    if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Mirrors the dependency-automation setup landed on `cisco-phone-mcp` and `cisco-cucm-mcp`, adapted for this repo (default branch `master`, npm, `Test & Coverage` check).

## Changes
- **`.github/dependabot.yml`** (new): weekly npm updates;
  - `groups` → one rolling PR for minor/patch;
  - `cooldown` (`semver-minor-days: 3`, `semver-patch-days: 3`) → supply-chain release-age delay;
  - majors ignored (human-only).
- **`.github/workflows/dependabot-automerge.yml`** (new): official `dependabot/fetch-metadata` pattern. Auto-merges **patch+minor** Dependabot PRs once the required `Test & Coverage` check passes. Hardened: `on: pull_request`, actor **and** author gated to `dependabot[bot]`, job-level least-privilege perms, per-PR concurrency.

## Companion settings (applied via API, not in this diff)
- `allow_auto_merge: true`
- Branch protection on `master` requiring `Test & Coverage`.
- Fork-PR approval tightened to **all_external_contributors** (untrusted PRs don't run CI until approved).