### PR TITLE
chore(deps): add github-actions ecosystem to Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,24 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    # Keep the SHA-pinned action refs current (with changelogs) now that
+    # sha_pinning_required is enforced. One rolling PR for minor/patch.
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+    cooldown:
+      semver-minor-days: 3
+      semver-patch-days: 3
+    # Major action bumps stay human-reviewed.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Adds a `github-actions` update block to `dependabot.yml` so the SHA-pinned action refs stay current automatically (with changelogs) now that `sha_pinning_required` is enforced. Same policy as npm: grouped minor/patch into one rolling PR, 3-day cooldown, majors human-only. These bumps auto-merge via the existing workflow once required checks pass.