### PR TITLE
ci: least-privilege top-level permissions on dependabot-automerge

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -11,6 +11,8 @@ concurrency:
   group: dependabot-automerge-${{ github.event.pull_request.number }}
   cancel-in-progress: false
 
+
+permissions: {}
 jobs:
   dependabot:
     name: Auto-merge Dependabot patch/minor PRs


### PR DESCRIPTION
Adds a top-level `permissions: {}` to the Dependabot auto-merge workflow so the default token grant for the workflow is empty; the single job keeps its explicit `contents: write` / `pull-requests: write`. Addresses the CodeRabbit least-privilege nitpick and keeps the workflow identical across all hardened repos.