### PR TITLE
Update Linear plugin for latest OpenClaw runtime

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,8 +38,7 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
     cooldown:
-      semver-minor-days: 3
-      semver-patch-days: 3
+      default-days: 3
     # Major action bumps stay human-reviewed.
     ignore:
       - dependency-name: "*"

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,436 @@
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { registerLinearProvider } from "./src/api/auth.js";
+import { registerCli } from "./src/infra/cli.js";
+import { createLinearTools } from "./src/tools/tools.js";
+import { handleLinearWebhook } from "./src/pipeline/webhook.js";
+import { handleOAuthCallback } from "./src/api/oauth-callback.js";
+import { LinearAgentApi, resolveLinearToken } from "./src/api/linear-api.js";
+import { createDispatchService } from "./src/pipeline/dispatch-service.js";
+import { registerDispatchMethods } from "./src/gateway/dispatch-methods.js";
+import { readDispatchState, lookupSessionMapping, getActiveDispatch, transitionDispatch } from "./src/pipeline/dispatch-state.js";
+import { triggerAudit, processVerdict } from "./src/pipeline/pipeline.js";
+import { markFlowTerminal } from "./src/pipeline/taskflow-bridge.js";
+import { createNotifierFromConfig } from "./src/infra/notify.js";
+import { readPlanningState, setPlanningCache } from "./src/pipeline/planning-state.js";
+import { createPlannerTools } from "./src/tools/planner-tools.js";
+import { registerDispatchCommands } from "./src/infra/commands.js";
+import { createDispatchHistoryTool } from "./src/tools/dispatch-history-tool.js";
+import { readDispatchState as readStateForHook, listActiveDispatches as listActiveForHook } from "./src/pipeline/dispatch-state.js";
+import { startTokenRefreshTimer, stopTokenRefreshTimer } from "./src/infra/token-refresh-timer.js";
+const SUCCESS_STATUSES = new Set(["ok", "success", "completed", "complete", "done", "pass", "passed"]);
+const FAILURE_STATUSES = new Set(["error", "failed", "failure", "timeout", "timed_out", "cancelled", "canceled", "aborted", "unknown"]);
+function parseCompletionSuccess(event) {
+    if (typeof event?.success === "boolean") {
+        return event.success;
+    }
+    const status = typeof event?.status === "string" ? event.status.trim().toLowerCase() : "";
+    if (status) {
+        if (SUCCESS_STATUSES.has(status))
+            return true;
+        if (FAILURE_STATUSES.has(status))
+            return false;
+    }
+    if (typeof event?.error === "string" && event.error.trim().length > 0) {
+        return false;
+    }
+    return true;
+}
+function extractCompletionOutput(event) {
+    if (typeof event?.output === "string" && event.output.trim().length > 0) {
+        return event.output;
+    }
+    if (typeof event?.result === "string" && event.result.trim().length > 0) {
+        return event.result;
+    }
+    const assistantBlocks = (event?.messages ?? [])
+        .filter((m) => m?.role === "assistant")
+        .flatMap((m) => {
+        if (typeof m?.content === "string") {
+            return [m.content];
+        }
+        if (Array.isArray(m?.content)) {
+            return m.content
+                .filter((b) => b?.type === "text" && typeof b?.text === "string")
+                .map((b) => b.text);
+        }
+        return [];
+    })
+        .filter((value) => value.trim().length > 0);
+    return assistantBlocks.join("\n");
+}
+export default function register(api) {
+    const pluginConfig = api.pluginConfig;
+    // Check token availability (config → env → auth profile store)
+    const tokenInfo = resolveLinearToken(pluginConfig);
+    if (!tokenInfo.accessToken) {
+        api.logger.warn("Linear: no access token found. Options: (1) run OAuth flow, (2) set LINEAR_ACCESS_TOKEN env var, " +
+            "(3) add accessToken to plugin config. Agent pipeline will not function without it.");
+    }
+    // Register Linear as an auth provider (OAuth flow with agent scopes)
+    registerLinearProvider(api);
+    // Register CLI commands: openclaw openclaw-linear auth|status
+    api.registerCli(({ program }) => registerCli(program, api), {
+        commands: ["openclaw-linear"],
+    });
+    // Register Linear tools for the agent
+    api.registerTool((ctx) => {
+        return createLinearTools(api, ctx);
+    });
+    // Register planner tools (context injected at runtime via setActivePlannerContext)
+    api.registerTool(() => createPlannerTools());
+    // Register dispatch_history tool for agent context
+    api.registerTool(() => createDispatchHistoryTool(api, pluginConfig));
+    // Register zero-LLM slash commands for dispatch ops
+    registerDispatchCommands(api);
+    // Register Linear webhook handler on a dedicated route
+    api.registerHttpRoute({
+        path: "/linear/webhook",
+        auth: "plugin",
+        match: "exact",
+        handler: async (req, res) => {
+            await handleLinearWebhook(api, req, res);
+        },
+    });
+    // Back-compat route so existing production webhook URLs keep working.
+    api.registerHttpRoute({
+        path: "/hooks/linear",
+        auth: "plugin",
+        match: "exact",
+        handler: async (req, res) => {
+            await handleLinearWebhook(api, req, res);
+        },
+    });
+    // Register OAuth callback route
+    api.registerHttpRoute({
+        path: "/linear/oauth/callback",
+        auth: "plugin",
+        match: "exact",
+        handler: async (req, res) => {
+            await handleOAuthCallback(api, req, res);
+        },
+    });
+    // Register dispatch monitor service (stale detection, session hydration, cleanup)
+    api.registerService(createDispatchService(api));
+    // Register dispatch gateway RPC methods (list, get, retry, escalate, cancel, stats)
+    registerDispatchMethods(api);
+    // Hydrate planning state on startup
+    readPlanningState(pluginConfig?.planningStatePath).then((state) => {
+        for (const session of Object.values(state.sessions)) {
+            if (session.status === "interviewing" || session.status === "plan_review") {
+                setPlanningCache(session);
+                api.logger.info(`Planning: restored session for ${session.projectName} (${session.rootIdentifier})`);
+            }
+        }
+    }).catch((err) => api.logger.warn(`Planning state hydration failed: ${err}`));
+    // ---------------------------------------------------------------------------
+    // Dispatch pipeline v2: notifier + completion lifecycle hooks
+    // ---------------------------------------------------------------------------
+    // Instantiate notifier (Discord, Slack, or both — config-driven)
+    const notify = createNotifierFromConfig(pluginConfig, api.runtime, api);
+    // ---------------------------------------------------------------------------
+    // Typed dispatch completion handler (shared by agent_end + subagent_ended)
+    // ---------------------------------------------------------------------------
+    const handleDispatchCompletion = async (sessionKey, success, output, hookName) => {
+        const statePath = pluginConfig?.dispatchStatePath;
+        const state = await readDispatchState(statePath);
+        const mapping = lookupSessionMapping(state, sessionKey);
+        if (!mapping)
+            return; // Not a dispatch sub-agent
+        const dispatch = getActiveDispatch(state, mapping.dispatchId);
+        if (!dispatch) {
+            api.logger.info(`${hookName}: dispatch ${mapping.dispatchId} no longer active`);
+            return;
+        }
+        // Stale event rejection — only process if attempt matches
+        if (dispatch.attempt !== mapping.attempt) {
+            api.logger.info(`${hookName}: stale event for ${mapping.dispatchId} ` +
+                `(event attempt=${mapping.attempt}, current=${dispatch.attempt})`);
+            return;
+        }
+        // Create Linear API for hook context
+        const tokenInfo = resolveLinearToken(pluginConfig);
+        if (!tokenInfo.accessToken) {
+            api.logger.error(`${hookName}: no Linear access token — cannot process dispatch event`);
+            return;
+        }
+        const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+            refreshToken: tokenInfo.refreshToken,
+            expiresAt: tokenInfo.expiresAt,
+        });
+        const hookCtx = {
+            api,
+            linearApi,
+            notify,
+            pluginConfig,
+            configPath: statePath,
+        };
+        if (mapping.phase === "worker") {
+            api.logger.info(`${hookName}: worker completed for ${mapping.dispatchId} - triggering audit`);
+            await triggerAudit(hookCtx, dispatch, { success, output }, sessionKey);
+        }
+        else if (mapping.phase === "audit") {
+            api.logger.info(`${hookName}: audit completed for ${mapping.dispatchId} - processing verdict`);
+            await processVerdict(hookCtx, dispatch, { success, output }, sessionKey);
+        }
+    };
+    const escalateDispatchError = async (sessionKey, err, hookName) => {
+        try {
+            const statePath = pluginConfig?.dispatchStatePath;
+            const state = await readDispatchState(statePath);
+            const mapping = sessionKey ? lookupSessionMapping(state, sessionKey) : null;
+            if (mapping) {
+                const dispatch = getActiveDispatch(state, mapping.dispatchId);
+                if (dispatch && dispatch.status !== "done" && dispatch.status !== "stuck" && dispatch.status !== "failed") {
+                    const stuckReason = `Hook error: ${err instanceof Error ? err.message : String(err)}`.slice(0, 500);
+                    await transitionDispatch(mapping.dispatchId, dispatch.status, "stuck", { stuckReason }, statePath);
+                    // Mirror the hook-error escalation into the openclaw task-flow
+                    // registry so the managed flow doesn't sit in "running" forever.
+                    markFlowTerminal(api, dispatch, "failed", stuckReason);
+                    await notify("escalation", {
+                        identifier: dispatch.issueIdentifier,
+                        title: dispatch.issueTitle ?? "Unknown",
+                        status: "stuck",
+                        reason: `Dispatch failed in ${mapping.phase} phase: ${stuckReason}`,
+                    }).catch(() => { });
+                }
+            }
+        }
+        catch (escalateErr) {
+            api.logger.error(`${hookName} escalation also failed: ${escalateErr}`);
+        }
+    };
+    // agent_end — fires when an agent run completes (primary dispatch handler)
+    api.on("agent_end", async (event, ctx) => {
+        const sessionKey = ctx?.sessionKey ?? "";
+        if (!sessionKey)
+            return;
+        try {
+            const output = extractCompletionOutput(event);
+            const success = parseCompletionSuccess(event);
+            await handleDispatchCompletion(sessionKey, success, output, "agent_end");
+        }
+        catch (err) {
+            api.logger.error(`agent_end hook error: ${err}`);
+            await escalateDispatchError(sessionKey, err, "agent_end");
+        }
+    });
+    // subagent_ended — fires when a subagent session ends (proper lifecycle hook, new in 3.7)
+    // This catches sessions_spawn sub-agents with structured outcome data.
+    api.on("subagent_ended", async (event, ctx) => {
+        const sessionKey = event.targetSessionKey ?? ctx?.childSessionKey ?? "";
+        if (!sessionKey)
+            return;
+        try {
+            const success = event.outcome === "ok";
+            const output = event.error ?? event.reason ?? "";
+            await handleDispatchCompletion(sessionKey, success, output, "subagent_ended");
+        }
+        catch (err) {
+            api.logger.error(`subagent_ended hook error: ${err}`);
+            await escalateDispatchError(sessionKey, err, "subagent_ended");
+        }
+    });
+    // session_start — track dispatch session lifecycle
+    api.on("session_start", async (event, ctx) => {
+        const sessionKey = ctx?.sessionKey ?? event?.sessionKey ?? "";
+        if (!sessionKey)
+            return;
+        try {
+            const statePath = pluginConfig?.dispatchStatePath;
+            const state = await readDispatchState(statePath);
+            const mapping = lookupSessionMapping(state, sessionKey);
+            if (mapping) {
+                api.logger.info(`session_start: dispatch ${mapping.dispatchId} phase=${mapping.phase} session started`);
+            }
+        }
+        catch {
+            // Never block session start for telemetry
+        }
+    });
+    // session_end — log dispatch session duration for observability
+    api.on("session_end", async (event, ctx) => {
+        const sessionKey = ctx?.sessionKey ?? event?.sessionKey ?? "";
+        if (!sessionKey)
+            return;
+        try {
+            const statePath = pluginConfig?.dispatchStatePath;
+            const state = await readDispatchState(statePath);
+            const mapping = lookupSessionMapping(state, sessionKey);
+            if (mapping) {
+                const durationSec = event.durationMs ? Math.round(event.durationMs / 1000) : "?";
+                api.logger.info(`session_end: dispatch ${mapping.dispatchId} phase=${mapping.phase} ` +
+                    `messages=${event.messageCount} duration=${durationSec}s`);
+            }
+        }
+        catch {
+            // Never block session end for telemetry
+        }
+    });
+    // after_compaction — log when dispatch sessions compact (visibility into context pressure)
+    api.on("after_compaction", async (event, ctx) => {
+        const sessionKey = ctx?.sessionKey ?? "";
+        if (!sessionKey)
+            return;
+        try {
+            const statePath = pluginConfig?.dispatchStatePath;
+            const state = await readDispatchState(statePath);
+            const mapping = lookupSessionMapping(state, sessionKey);
+            if (mapping) {
+                api.logger.warn(`after_compaction: dispatch ${mapping.dispatchId} phase=${mapping.phase} ` +
+                    `compacted ${event.compactedCount} messages (${event.messageCount} remaining)`);
+            }
+        }
+        catch {
+            // Never block compaction pipeline
+        }
+    });
+    // before_reset — clean up dispatch tracking when a session is reset
+    api.on("before_reset", async (event, ctx) => {
+        const sessionKey = ctx?.sessionKey ?? "";
+        if (!sessionKey)
+            return;
+        try {
+            const statePath = pluginConfig?.dispatchStatePath;
+            const state = await readDispatchState(statePath);
+            const mapping = lookupSessionMapping(state, sessionKey);
+            if (mapping) {
+                api.logger.warn(`before_reset: dispatch ${mapping.dispatchId} phase=${mapping.phase} session reset ` +
+                    `(reason: ${event.reason ?? "unknown"})`);
+            }
+        }
+        catch {
+            // Never block reset
+        }
+    });
+    api.logger.info("Dispatch lifecycle hooks registered: agent_end, subagent_ended, session_start, session_end, after_compaction, before_reset");
+    // Inject recent dispatch history as context for worker/audit agents.
+    api.on("before_prompt_build", async (_event, ctx) => {
+        try {
+            const sessionKey = ctx?.sessionKey ?? "";
+            if (!sessionKey.startsWith("linear-worker-") && !sessionKey.startsWith("linear-audit-"))
+                return;
+            const statePath = pluginConfig?.dispatchStatePath;
+            const state = await readStateForHook(statePath);
+            const active = listActiveForHook(state);
+            // Include up to 3 recent active dispatches as context
+            const recent = active.slice(0, 3);
+            if (recent.length === 0)
+                return;
+            const lines = recent.map(d => `- **${d.issueIdentifier}** (${d.tier}): ${d.status}, attempt ${d.attempt}`);
+            return {
+                prependContext: `<dispatch-history>\nActive dispatches:\n${lines.join("\n")}\n</dispatch-history>\n\n`,
+            };
+        }
+        catch {
+            // Never block agent start for telemetry
+        }
+    });
+    // Hard gate: prepend planning-only constraints to code_run when issue is not "started".
+    // Even if the orchestrator LLM ignores scope rules, the coding agent receives hard constraints.
+    api.on("before_tool_call", async (event, _ctx) => {
+        if (event.toolName !== "code_run")
+            return;
+        const { getCurrentSession } = await import("./src/pipeline/active-session.js");
+        const session = getCurrentSession();
+        if (!session?.issueId)
+            return; // Non-Linear context, allow
+        // Check issue state
+        const hookTokenInfo = resolveLinearToken(pluginConfig);
+        if (!hookTokenInfo.accessToken)
+            return;
+        const hookLinearApi = new LinearAgentApi(hookTokenInfo.accessToken, {
+            refreshToken: hookTokenInfo.refreshToken,
+            expiresAt: hookTokenInfo.expiresAt,
+        });
+        try {
+            const issue = await hookLinearApi.getIssueDetails(session.issueId);
+            const stateType = issue?.state?.type ?? "";
+            const isStarted = stateType === "started";
+            if (!isStarted) {
+                const constraint = [
+                    "CRITICAL CONSTRAINT — PLANNING MODE ONLY:",
+                    `This issue (${session.issueIdentifier}) is in "${issue?.state?.name ?? stateType}" state — NOT In Progress.`,
+                    "You may ONLY:",
+                    "- Read and explore files to understand the codebase",
+                    "- Write plan files (PLAN.md, notes, design outlines)",
+                    "- Search code to inform planning",
+                    "You MUST NOT:",
+                    "- Create, modify, or delete source code, config, or infrastructure files",
+                    "- Run system commands that change state (deploys, installs, migrations)",
+                    "- Make external API requests that modify data",
+                    "- Build, implement, or scaffold any application code",
+                    "Plan and explore ONLY. Do not implement anything.",
+                    "---",
+                ].join("\n");
+                const originalPrompt = event.params?.prompt ?? "";
+                return {
+                    params: { ...event.params, prompt: `${constraint}\n${originalPrompt}` },
+                };
+            }
+        }
+        catch (err) {
+            api.logger.warn(`before_tool_call: issue state check failed: ${err}`);
+            // Don't block on failure — fall through to allow
+        }
+    });
+    // Narration Guard: catch short "Let me explore..." responses that narrate intent
+    // without actually calling tools, and append a warning for the user.
+    const NARRATION_PATTERNS = [
+        /let me (explore|look|investigate|check|dig|analyze|search|find|review|examine)/i,
+        /i('ll| will) (explore|look into|investigate|check|dig into|analyze|search|find|review)/i,
+        /let me (take a look|dive into|pull up|go through)/i,
+    ];
+    const MAX_SHORT_RESPONSE = 250;
+    api.on("message_sending", (event) => {
+        const text = event?.content ?? "";
+        if (!text || text.length > MAX_SHORT_RESPONSE)
+            return;
+        const isNarration = NARRATION_PATTERNS.some((p) => p.test(text));
+        if (!isNarration)
+            return;
+        api.logger.warn(`Narration guard triggered: "${text.slice(0, 80)}..."`);
+        return {
+            content: text +
+                "\n\n⚠️ _Agent acknowledged but may not have completed the task. Try asking again or rephrase your request._",
+        };
+    });
+    // Check CLI availability (Codex, Claude, Gemini)
+    const cliChecks = {};
+    const defaultBinDir = join(process.env.HOME ?? homedir(), ".npm-global", "bin");
+    const cliBins = [
+        ["codex", pluginConfig?.codexBin ?? join(defaultBinDir, "codex"), "npm install -g @openai/codex"],
+        ["claude", pluginConfig?.claudeBin ?? join(defaultBinDir, "claude"), "npm install -g @anthropic-ai/claude-code"],
+        ["gemini", pluginConfig?.geminiBin ?? join(defaultBinDir, "gemini"), "npm install -g @anthropic-ai/gemini-cli"],
+    ];
+    for (const [name, bin, installCmd] of cliBins) {
+        try {
+            const raw = execFileSync(bin, ["--version"], {
+                encoding: "utf8",
+                timeout: 15_000,
+                env: { ...process.env, CLAUDECODE: undefined },
+            }).trim();
+            cliChecks[name] = raw || "unknown";
+        }
+        catch {
+            // Fallback: check if the file exists (execFileSync can fail in worker contexts)
+            try {
+                require("node:fs").accessSync(bin, require("node:fs").constants.X_OK);
+                cliChecks[name] = "installed (version check skipped)";
+            }
+            catch {
+                cliChecks[name] = "not found";
+                api.logger.warn(`${name} CLI not found at ${bin}. The ${name}_run tool will fail. Install with: ${installCmd}`);
+            }
+        }
+    }
+    const agentId = pluginConfig?.defaultAgentId ?? "default";
+    const orchestration = pluginConfig?.enableOrchestration !== false ? "enabled" : "disabled";
+    const cliSummary = Object.entries(cliChecks).map(([k, v]) => `${k}: ${v}`).join(", ");
+    api.logger.info(`Linear agent extension registered (agent: ${agentId}, token: ${tokenInfo.source !== "none" ? `${tokenInfo.source}` : "missing"}, ${cliSummary}, orchestration: ${orchestration})`);
+    // Start proactive token refresh timer (runs immediately, then every 6h)
+    startTokenRefreshTimer(api, pluginConfig);
+    // Clean up timer on process exit
+    process.on("beforeExit", () => stopTokenRefreshTimer());
+}

--- a/dist/src/agent/agent.js
+++ b/dist/src/agent/agent.js
@@ -1,0 +1,396 @@
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { mkdirSync } from "node:fs";
+import { InactivityWatchdog, resolveWatchdogConfig } from "./watchdog.js";
+function resolveAgentDirs(agentId, config) {
+    const home = homedir();
+    const agentList = config?.agents?.list;
+    const agentEntry = agentList?.find((a) => a.id === agentId);
+    // Workspace: agent-specific override → agents.defaults.workspace → fallback
+    const workspaceDir = agentEntry?.workspace
+        ?? config?.agents?.defaults?.workspace
+        ?? join(home, ".openclaw", "workspace");
+    // Agent runtime dir: always ~/.openclaw/agents/{agentId}/agent
+    // (matches OpenClaw's internal structure)
+    const agentDir = join(home, ".openclaw", "agents", agentId, "agent");
+    mkdirSync(agentDir, { recursive: true });
+    return { workspaceDir, agentDir };
+}
+/**
+ * Run an agent with automatic retry on watchdog kill.
+ *
+ * Tries embedded runner first (if streaming callbacks provided), falls back
+ * to subprocess. If the inactivity watchdog kills the run, retries once.
+ */
+export async function runAgent(params) {
+    const maxAttempts = 2;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        const result = await runAgentOnce(params);
+        if (result.success || !result.watchdogKilled || attempt === maxAttempts - 1) {
+            return result;
+        }
+        params.api.logger.warn(`Agent ${params.agentId} killed by watchdog, retrying (attempt ${attempt + 1}/${maxAttempts})`);
+        // Emit Linear activity about the retry if streaming
+        if (params.streaming) {
+            params.streaming.linearApi.emitActivity(params.streaming.agentSessionId, {
+                type: "error",
+                body: `Agent killed by inactivity watchdog — no I/O for the configured threshold. Retrying...`,
+            }).catch(() => { });
+        }
+    }
+    // Unreachable, but TypeScript needs it
+    return { success: false, output: "Watchdog retry exhausted" };
+}
+// ---------------------------------------------------------------------------
+// Date/time injection — every LLM request gets the current timestamp so models
+// don't hallucinate the year (Kimi K2.5 thinks it's 2025).
+// ---------------------------------------------------------------------------
+function buildDateContext() {
+    const now = new Date();
+    const iso = now.toISOString();
+    // Human-readable: "Tuesday, February 18, 2026, 11:42 PM CST"
+    const human = now.toLocaleString("en-US", {
+        weekday: "long",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "2-digit",
+        timeZoneName: "short",
+    });
+    return `[Current date/time: ${human} (${iso})]`;
+}
+/**
+ * Single attempt to run an agent (no retry logic).
+ */
+async function runAgentOnce(params) {
+    const { api, agentId, sessionId, streaming, readOnly, toolsDeny } = params;
+    // Inject current timestamp into every LLM request
+    const message = `${buildDateContext()}\n\n${params.message}`;
+    const pluginConfig = api.pluginConfig;
+    const wdConfig = resolveWatchdogConfig(agentId, pluginConfig);
+    const timeoutMs = params.timeoutMs ?? wdConfig.maxTotalMs;
+    api.logger.info(`Dispatching agent ${agentId} for session ${sessionId} (timeout=${Math.round(timeoutMs / 1000)}s, inactivity=${Math.round(wdConfig.inactivityMs / 1000)}s${readOnly ? ", mode=READ_ONLY" : ""})`);
+    // Try embedded runner first (has streaming callbacks)
+    if (streaming) {
+        try {
+            return await runEmbedded(api, agentId, sessionId, message, timeoutMs, streaming, wdConfig.inactivityMs, readOnly, toolsDeny);
+        }
+        catch (err) {
+            // Read-only mode MUST NOT fall back to subprocess — subprocess runs a
+            // full agent with no way to enforce the tool deny policy.
+            if (readOnly) {
+                api.logger.error(`Embedded runner failed in read-only mode, refusing subprocess fallback: ${err}`);
+                return { success: false, output: "Read-only agent run failed (embedded runner unavailable)." };
+            }
+            api.logger.warn(`Embedded runner failed, falling back to subprocess: ${err}`);
+        }
+    }
+    // Fallback: subprocess (no streaming)
+    if (readOnly) {
+        api.logger.error("Cannot run read-only agent via subprocess — no tool policy enforcement");
+        return { success: false, output: "Read-only agent run requires the embedded runner." };
+    }
+    return runSubprocess(api, agentId, sessionId, message, timeoutMs);
+}
+/**
+ * Embedded agent runner with real-time streaming to Linear and inactivity watchdog.
+ */
+// Tools denied in read-only mode.  Uses OpenClaw group:* shorthands where
+// possible (see https://docs.openclaw.ai/tools).  Covers every built-in
+// tool that can mutate the filesystem, execute commands, or produce
+// side-effects beyond the Linear API calls the plugin makes after the run.
+//
+// NOT denied (read-only tools the triage agent keeps):
+//   read, glob, grep/search          — codebase inspection
+//   group:web (web_search, web_fetch) — external context
+//   group:memory (memory_search/get)  — knowledge retrieval
+//   sessions_list, sessions_history   — read-only introspection
+const READ_ONLY_DENY = [
+    // group:fs = read + write + edit + apply_patch — but we need read,
+    // so deny the write-capable members individually.
+    "write", "edit", "apply_patch",
+    // Full groups that are entirely write/side-effect oriented:
+    "group:runtime", // exec, bash, process
+    "group:messaging", // message
+    "group:ui", // browser, canvas
+    "group:automation", // cron, gateway
+    "group:nodes", // nodes
+    // Individual tools not covered by a group:
+    "sessions_spawn", "sessions_send", // agent orchestration
+    "tts", // audio file generation
+    "image", // image file generation
+];
+async function runEmbedded(api, agentId, sessionId, message, timeoutMs, streaming, inactivityMs, readOnly, toolsDeny) {
+    // Load config so we can resolve agent dirs and providers correctly.
+    const origConfig = await api.runtime.config.loadConfig();
+    let config = origConfig;
+    let configAny = config;
+    // ── Read-only enforcement ──────────────────────────────────────────
+    // Clone the config and inject a tools.deny policy that strips every
+    // write-capable tool.  The deny list is merged with any existing deny
+    // entries so we don't clobber operator-level restrictions.
+    if (readOnly) {
+        configAny = JSON.parse(JSON.stringify(configAny));
+        config = configAny;
+        if (!configAny.tools)
+            configAny.tools = {};
+        const existing = Array.isArray(configAny.tools.deny) ? configAny.tools.deny : [];
+        configAny.tools.deny = [...new Set([...existing, ...READ_ONLY_DENY])];
+        api.logger.info(`Read-only mode: tools.deny = [${configAny.tools.deny.join(", ")}]`);
+    }
+    // ── Additional toolsDeny entries ─────────────────────────────────────
+    if (toolsDeny?.length) {
+        if (config === origConfig) {
+            configAny = JSON.parse(JSON.stringify(origConfig));
+            config = configAny;
+        }
+        if (!configAny.tools)
+            configAny.tools = {};
+        const existing = Array.isArray(configAny.tools.deny) ? configAny.tools.deny : [];
+        configAny.tools.deny = [...new Set([...existing, ...toolsDeny])];
+    }
+    // Resolve workspace and agent dirs from config (ext API ignores agentId).
+    const dirs = resolveAgentDirs(agentId, configAny);
+    const { workspaceDir, agentDir } = dirs;
+    const runId = randomUUID();
+    // Build session file path under the correct agent's sessions directory.
+    const sessionsDir = join(agentDir, "sessions");
+    try {
+        mkdirSync(sessionsDir, { recursive: true });
+    }
+    catch { }
+    const sessionFile = join(sessionsDir, `${sessionId}.jsonl`);
+    // Resolve model/provider from config — default is anthropic which requires
+    // a separate API key. Our agents use openrouter.
+    const agentList = configAny?.agents?.list;
+    const agentEntry = agentList?.find((a) => a.id === agentId);
+    const modelRef = agentEntry?.model?.primary ??
+        configAny?.agents?.defaults?.model?.primary ??
+        `${api.runtime.agent.defaults.provider}/${api.runtime.agent.defaults.model}`;
+    // Parse "provider/model-id" format (e.g. "openrouter/moonshotai/kimi-k2.5")
+    const slashIdx = modelRef.indexOf("/");
+    const provider = slashIdx > 0 ? modelRef.slice(0, slashIdx) : api.runtime.agent.defaults.provider;
+    const model = slashIdx > 0 ? modelRef.slice(slashIdx + 1) : modelRef;
+    api.logger.info(`Embedded agent run: agent=${agentId} session=${sessionId} runId=${runId} provider=${provider} model=${model} workspaceDir=${workspaceDir} agentDir=${agentDir}`);
+    const emit = (content) => {
+        streaming.linearApi.emitActivity(streaming.agentSessionId, content).catch((err) => {
+            api.logger.warn(`Activity emit failed: ${err}`);
+        });
+    };
+    // --- Inactivity watchdog ---
+    const controller = new AbortController();
+    const watchdog = new InactivityWatchdog({
+        inactivityMs,
+        label: `embedded:${agentId}:${sessionId}`,
+        logger: api.logger,
+        onKill: () => {
+            // The AbortController wired to runEmbeddedPiAgent below is the
+            // canonical way to stop an in-flight embedded run; no extra
+            // host-side abort call is needed.
+            controller.abort();
+        },
+    });
+    // Track last emitted tool to avoid duplicates
+    let lastToolAction = "";
+    // Derive a friendly label from cli_ tool names: cli_codex→"Codex", cli_claude→"Claude"
+    const cliLabel = (name) => name.startsWith("cli_") ? name.slice(4).charAt(0).toUpperCase() + name.slice(5) : name;
+    watchdog.start();
+    const result = await api.runtime.agent.runEmbeddedPiAgent({
+        sessionId,
+        sessionFile,
+        workspaceDir,
+        agentDir,
+        prompt: message,
+        agentId,
+        runId,
+        timeoutMs,
+        config,
+        provider,
+        model,
+        abortSignal: controller.signal,
+        shouldEmitToolResult: () => true,
+        shouldEmitToolOutput: () => true,
+        ...(readOnly ? {
+            extraSystemPrompt: [
+                "READ-ONLY MODE: You may read and search files but you MUST NOT",
+                "write, edit, create, or delete any files. Do not run shell commands.",
+                "Your only output is your text response.",
+            ].join(" "),
+        } : {}),
+        // Stream reasoning/thinking to Linear
+        onReasoningStream: (payload) => {
+            watchdog.tick();
+            const text = payload.text?.trim();
+            if (text && text.length > 10) {
+                emit({ type: "thought", body: text.slice(0, 500) });
+            }
+        },
+        // Stream tool results to Linear
+        onToolResult: (payload) => {
+            watchdog.tick();
+            const text = payload.text?.trim();
+            if (text) {
+                // Truncate tool results for activity display
+                const truncated = text.length > 300 ? text.slice(0, 300) + "..." : text;
+                const prefix = lastToolAction.startsWith("cli_") ? `[${cliLabel(lastToolAction)}] ` : "";
+                emit({ type: "action", action: `${prefix}${lastToolAction || "Tool result"}`, parameter: truncated });
+            }
+        },
+        // Raw agent events — capture tool starts/ends/updates
+        onAgentEvent: (evt) => {
+            watchdog.tick();
+            const { stream, data } = evt;
+            if (stream !== "tool")
+                return;
+            const phase = String(data.phase ?? "");
+            const toolName = String(data.name ?? "tool");
+            const meta = typeof data.meta === "string" ? data.meta : "";
+            const rawInput = data.input;
+            const input = typeof rawInput === "string" ? rawInput : "";
+            // Parse structured input for richer detail on cli_* tools
+            let inputObj = null;
+            if (rawInput && typeof rawInput === "object") {
+                inputObj = rawInput;
+            }
+            else if (input.startsWith("{")) {
+                try {
+                    inputObj = JSON.parse(input);
+                }
+                catch { }
+            }
+            // Tool execution start — emit action with tool name + available context
+            if (phase === "start") {
+                lastToolAction = toolName;
+                // cli_codex / cli_claude / cli_gemini: emit a thought + action so the
+                // user immediately sees what the agent is dispatching and why.
+                if (toolName.startsWith("cli_") && inputObj) {
+                    const tag = cliLabel(toolName);
+                    const prompt = String(inputObj.prompt ?? "").slice(0, 250);
+                    const workDir = inputObj.workingDir ? ` in ${inputObj.workingDir}` : "";
+                    emit({ type: "thought", body: `[${tag}] Starting${workDir}: "${prompt}"\n\n${toolName}\nin progress` });
+                    emit({ type: "action", action: `[${tag}] Running${workDir}`, parameter: prompt });
+                }
+                else {
+                    const detail = input || meta || toolName;
+                    emit({ type: "action", action: `Running ${toolName}`, parameter: detail.slice(0, 300) });
+                }
+            }
+            // Tool execution update — partial progress (keeps Linear UI alive for long tools)
+            if (phase === "update") {
+                const detail = meta || input || "in progress";
+                const prefix = toolName.startsWith("cli_") ? `[${cliLabel(toolName)}] ` : "";
+                emit({ type: "action", action: `${prefix}${toolName}`, parameter: detail.slice(0, 300) });
+            }
+            // Tool execution completed successfully
+            if (phase === "result" && !data.isError) {
+                const detail = meta ? meta.slice(0, 300) : "completed";
+                const prefix = toolName.startsWith("cli_") ? `[${cliLabel(toolName)}] ` : "";
+                emit({ type: "action", action: `${prefix}${toolName} done`, parameter: detail });
+            }
+            // Tool execution result with error
+            if (phase === "result" && data.isError) {
+                const prefix = toolName.startsWith("cli_") ? `[${cliLabel(toolName)}] ` : "";
+                emit({ type: "action", action: `${prefix}${toolName} failed`, parameter: (meta || "error").slice(0, 300) });
+            }
+        },
+        // Partial assistant text (for long responses)
+        onPartialReply: (payload) => {
+            watchdog.tick();
+            // We don't emit every partial chunk to avoid flooding Linear
+            // The final response will be posted as a comment
+        },
+    });
+    watchdog.stop();
+    // Extract output text from payloads
+    const payloads = result.payloads ?? [];
+    const outputText = payloads
+        .map((p) => p.text)
+        .filter(Boolean)
+        .join("\n\n");
+    // Check if watchdog killed the run
+    if (watchdog.wasKilled) {
+        const silenceSec = Math.round(watchdog.silenceMs / 1000);
+        api.logger.warn(`Embedded agent killed by watchdog: agent=${agentId} session=${sessionId} silence=${silenceSec}s`);
+        return {
+            success: false,
+            output: outputText || `Agent killed by inactivity watchdog after ${silenceSec}s of silence.`,
+            watchdogKilled: true,
+        };
+    }
+    if (result.meta?.error) {
+        api.logger.error(`Embedded agent error: ${result.meta.error.kind}: ${result.meta.error.message}`);
+        return { success: false, output: outputText || result.meta.error.message };
+    }
+    api.logger.info(`Embedded agent completed: agent=${agentId} session=${sessionId} duration=${result.meta.durationMs}ms`);
+    return { success: true, output: outputText || "(no output)" };
+}
+/**
+ * Subprocess fallback (no streaming, used when no Linear session context).
+ */
+async function runSubprocess(api, agentId, sessionId, message, timeoutMs) {
+    const command = [
+        "openclaw",
+        "agent",
+        "--agent",
+        agentId,
+        "--session-id",
+        sessionId,
+        "--message",
+        message,
+        "--timeout",
+        String(Math.floor(timeoutMs / 1000)),
+        "--json",
+    ];
+    const result = await api.runtime.system.runCommandWithTimeout(command, { timeoutMs });
+    if (result.code !== 0) {
+        const error = result.stderr || result.stdout || "no output";
+        api.logger.error(`Agent ${agentId} failed (${result.code}): ${error}`);
+        return { success: false, output: error };
+    }
+    const raw = result.stdout || "";
+    api.logger.info(`Agent ${agentId} completed for session ${sessionId}`);
+    // Extract clean text from --json output.
+    // The subprocess stdout may contain plugin init log lines before the JSON blob.
+    // Strip everything before the first `{` to isolate the JSON envelope.
+    const extracted = extractJsonFromOutput(raw);
+    if (extracted)
+        return { success: true, output: extracted };
+    return { success: true, output: raw };
+}
+/**
+ * Extract text from subprocess --json output. Handles:
+ * - Log noise before the JSON blob (plugin init lines)
+ * - Both envelope shapes: `{ payloads }` (flat) and `{ result: { payloads } }` (nested)
+ */
+function extractJsonFromOutput(raw) {
+    // The subprocess stdout may contain plugin init log lines before the JSON
+    // result blob. Try parsing the whole thing first; if that fails, scan lines
+    // backwards for a `{` that starts a valid JSON envelope with payloads.
+    const candidates = [raw];
+    // Also try from each line that starts with `{` (the JSON blob typically
+    // starts on its own line after log noise).
+    const lines = raw.split("\n");
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].trimStart().startsWith("{")) {
+            candidates.push(lines.slice(i).join("\n"));
+        }
+    }
+    for (const candidate of candidates) {
+        try {
+            const parsed = JSON.parse(candidate);
+            // Try both envelope shapes: flat `{ payloads }` and nested `{ result: { payloads } }`
+            const payloads = parsed?.payloads ?? parsed?.result?.payloads;
+            if (Array.isArray(payloads) && payloads.length > 0) {
+                const text = payloads.map((p) => p.text).filter(Boolean).join("\n\n");
+                if (text)
+                    return text;
+            }
+        }
+        catch {
+            // Not valid JSON at this position — try next candidate
+        }
+    }
+    return null;
+}

--- a/dist/src/agent/watchdog.js
+++ b/dist/src/agent/watchdog.js
@@ -1,0 +1,123 @@
+/**
+ * watchdog.ts — I/O inactivity watchdog for agent sessions.
+ *
+ * Resets a countdown timer on every tick(). If no tick arrives within
+ * the inactivity threshold, fires onKill(). Also provides a config
+ * resolver that reads per-agent timeouts from agent-profiles.json.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+// ---------------------------------------------------------------------------
+// Defaults (seconds — matches config units)
+// ---------------------------------------------------------------------------
+export const DEFAULT_INACTIVITY_SEC = 120; // 2 min
+export const DEFAULT_MAX_TOTAL_SEC = 7200; // 2 hrs
+export const DEFAULT_TOOL_TIMEOUT_SEC = 600; // 10 min
+export class InactivityWatchdog {
+    timer = null;
+    inactivityMs;
+    label;
+    logger;
+    onKill;
+    lastActivityAt = Date.now();
+    killed = false;
+    started = false;
+    constructor(opts) {
+        this.inactivityMs = opts.inactivityMs;
+        this.label = opts.label;
+        this.logger = opts.logger;
+        this.onKill = opts.onKill;
+    }
+    /** Start the watchdog. Call after the process/run is launched. */
+    start() {
+        if (this.started)
+            return;
+        this.started = true;
+        this.lastActivityAt = Date.now();
+        this.scheduleCheck();
+        this.logger.info(`Watchdog started: ${this.label} (inactivity=${this.inactivityMs}ms)`);
+    }
+    /** Record an I/O activity tick. Resets the inactivity countdown. */
+    tick() {
+        this.lastActivityAt = Date.now();
+    }
+    /** Stop the watchdog (normal completion). */
+    stop() {
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+        this.started = false;
+    }
+    /** Whether the watchdog triggered a kill. */
+    get wasKilled() {
+        return this.killed;
+    }
+    /** Milliseconds since last activity. */
+    get silenceMs() {
+        return Date.now() - this.lastActivityAt;
+    }
+    scheduleCheck() {
+        const remaining = Math.max(1000, this.inactivityMs - (Date.now() - this.lastActivityAt));
+        this.timer = setTimeout(() => {
+            if (this.killed || !this.started)
+                return;
+            const silence = Date.now() - this.lastActivityAt;
+            if (silence >= this.inactivityMs) {
+                this.killed = true;
+                this.logger.warn(`Watchdog KILL: ${this.label} — no I/O for ${Math.round(silence / 1000)}s ` +
+                    `(threshold: ${this.inactivityMs / 1000}s)`);
+                try {
+                    const result = this.onKill("inactivity");
+                    if (result && typeof result.catch === "function") {
+                        result.catch((err) => {
+                            this.logger.warn(`Watchdog onKill error: ${err}`);
+                        });
+                    }
+                }
+                catch (err) {
+                    this.logger.warn(`Watchdog onKill error: ${err}`);
+                }
+            }
+            else {
+                // Activity happened during the wait — reschedule for remaining time
+                this.scheduleCheck();
+            }
+        }, remaining);
+    }
+}
+const PROFILES_PATH = join(homedir(), ".openclaw", "agent-profiles.json");
+function loadProfileWatchdog(agentId) {
+    try {
+        const raw = readFileSync(PROFILES_PATH, "utf8");
+        const profiles = JSON.parse(raw).agents ?? {};
+        return profiles[agentId]?.watchdog ?? null;
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * Resolve watchdog config for an agent.
+ *
+ * Priority: agent-profiles.json → plugin config → hardcoded defaults.
+ * All config values are in seconds; output is in ms.
+ */
+export function resolveWatchdogConfig(agentId, pluginConfig) {
+    const profile = loadProfileWatchdog(agentId);
+    const inactivitySec = profile?.inactivitySec ??
+        pluginConfig?.inactivitySec ??
+        DEFAULT_INACTIVITY_SEC;
+    const maxTotalSec = profile?.maxTotalSec ??
+        pluginConfig?.maxTotalSec ??
+        DEFAULT_MAX_TOTAL_SEC;
+    const toolTimeoutSec = profile?.toolTimeoutSec ??
+        pluginConfig?.toolTimeoutSec ??
+        DEFAULT_TOOL_TIMEOUT_SEC;
+    return {
+        inactivityMs: inactivitySec * 1000,
+        maxTotalMs: maxTotalSec * 1000,
+        toolTimeoutMs: toolTimeoutSec * 1000,
+    };
+}

--- a/dist/src/api/auth.js
+++ b/dist/src/api/auth.js
@@ -1,0 +1,101 @@
+export const LINEAR_OAUTH_AUTH_URL = "https://linear.app/oauth/authorize";
+export const LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token";
+// Agent scopes: read/write + assignable (appear in assignment menus) + mentionable (respond to @mentions)
+export const LINEAR_AGENT_SCOPES = "read,write,app:assignable,app:mentionable";
+// Token refresh helper — Linear tokens expire; refresh before they do
+export async function refreshLinearToken(clientId, clientSecret, refreshToken) {
+    const response = await fetch(LINEAR_OAUTH_TOKEN_URL, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Accept: "application/json",
+        },
+        body: new URLSearchParams({
+            grant_type: "refresh_token",
+            client_id: clientId,
+            client_secret: clientSecret,
+            refresh_token: refreshToken,
+        }),
+    });
+    if (!response.ok) {
+        const error = await response.text();
+        throw new Error(`Linear token refresh failed (${response.status}): ${error}`);
+    }
+    return response.json();
+}
+export function registerLinearProvider(api) {
+    const provider = {
+        id: "linear",
+        label: "Linear",
+        auth: [
+            {
+                id: "oauth",
+                label: "OAuth",
+                kind: "oauth",
+                run: async (ctx) => {
+                    // This is a placeholder for the actual OAuth flow.
+                    // In a real implementation, we would use ctx.oauth.createVpsAwareHandlers
+                    // and perform the Linear OAuth2 flow.
+                    const pluginConfig = api.pluginConfig;
+                    const clientId = pluginConfig?.clientId ?? process.env.LINEAR_CLIENT_ID;
+                    const clientSecret = pluginConfig?.clientSecret ?? process.env.LINEAR_CLIENT_SECRET;
+                    if (!clientId || !clientSecret) {
+                        throw new Error("Linear client ID and secret must be configured in plugin config or environment.");
+                    }
+                    const prompter = ctx.prompter;
+                    const spin = prompter.progress("Starting Linear OAuth flow…");
+                    const handlers = ctx.oauth.createVpsAwareHandlers({
+                        isRemote: ctx.isRemote,
+                        prompter,
+                        runtime: ctx.runtime,
+                        spin,
+                        openUrl: ctx.openUrl,
+                        localBrowserMessage: "Waiting for Linear authorization…",
+                    });
+                    // Linear OAuth requires a redirect_uri.
+                    const gatewayPort = process.env.OPENCLAW_GATEWAY_PORT ?? "18789";
+                    const redirectUri = pluginConfig?.redirectUri ?? process.env.LINEAR_REDIRECT_URI ?? `http://localhost:${gatewayPort}/linear/oauth/callback`;
+                    const state = Math.random().toString(36).substring(7);
+                    const authUrl = `${LINEAR_OAUTH_AUTH_URL}?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=${encodeURIComponent(LINEAR_AGENT_SCOPES)}&state=${state}&actor=app`;
+                    await handlers.onAuth({ url: authUrl });
+                    const code = await handlers.onPrompt({
+                        message: "Enter the code from Linear",
+                    });
+                    spin.update("Exchanging code for token…");
+                    const response = await fetch(LINEAR_OAUTH_TOKEN_URL, {
+                        method: "POST",
+                        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                        body: new URLSearchParams({
+                            grant_type: "authorization_code",
+                            code,
+                            client_id: clientId,
+                            client_secret: clientSecret,
+                            redirect_uri: redirectUri,
+                        }),
+                    });
+                    if (!response.ok) {
+                        const error = await response.text();
+                        throw new Error(`Linear OAuth failed: ${error}`);
+                    }
+                    const tokens = await response.json();
+                    spin.stop("Linear authorized!");
+                    return {
+                        profiles: [
+                            {
+                                profileId: "linear:default",
+                                credential: {
+                                    type: "oauth",
+                                    provider: "linear",
+                                    access: tokens.access_token,
+                                    refresh: tokens.refresh_token,
+                                    expires: Date.now() + (tokens.expires_in * 1000),
+                                },
+                            },
+                        ],
+                    };
+                },
+            },
+        ],
+    };
+    api.registerProvider(provider);
+}

--- a/dist/src/api/linear-api.js
+++ b/dist/src/api/linear-api.js
@@ -1,0 +1,505 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { refreshLinearToken } from "./auth.js";
+import { withResilience } from "../infra/resilience.js";
+export const LINEAR_GRAPHQL_URL = "https://api.linear.app/graphql";
+export const AUTH_PROFILES_PATH = join(homedir(), ".openclaw", "auth-profiles.json");
+/**
+ * Resolve a Linear access token from multiple sources in priority order:
+ * 1. pluginConfig.accessToken (static config)
+ * 2. LINEAR_ACCESS_TOKEN env var
+ * 3. Auth profile store (~/.openclaw/auth-profiles.json) — from OAuth flow
+ */
+export function resolveLinearToken(pluginConfig) {
+    // 1. Static config
+    const fromConfig = pluginConfig?.accessToken;
+    if (typeof fromConfig === "string" && fromConfig) {
+        return { accessToken: fromConfig, source: "config" };
+    }
+    // 2. Auth profile store (from OAuth flow) — OAuth tokens carry
+    //    app:assignable/app:mentionable scopes needed for Agent Sessions.
+    //    Token refresh is handled by the 6-hour proactive timer; if it's
+    //    expired here, fail loudly so we know the refresh is broken.
+    try {
+        const raw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+        const store = JSON.parse(raw);
+        const profile = store?.profiles?.["linear:default"];
+        if (profile?.accessToken || profile?.access) {
+            return {
+                accessToken: profile.accessToken ?? profile.access,
+                refreshToken: profile.refreshToken ?? profile.refresh,
+                expiresAt: profile.expiresAt ?? profile.expires,
+                source: "profile",
+            };
+        }
+    }
+    catch {
+        // Profile store doesn't exist or is unreadable
+    }
+    // 3. Env var fallback
+    const fromEnv = process.env.LINEAR_ACCESS_TOKEN ?? process.env.LINEAR_API_KEY;
+    if (fromEnv) {
+        return { accessToken: fromEnv, source: "env" };
+    }
+    return { accessToken: null, source: "none" };
+}
+export class LinearAgentApi {
+    accessToken;
+    refreshToken;
+    expiresAt;
+    clientId;
+    clientSecret;
+    viewerId;
+    constructor(accessToken, opts) {
+        this.accessToken = accessToken;
+        this.refreshToken = opts?.refreshToken;
+        this.expiresAt = opts?.expiresAt;
+        this.clientId = opts?.clientId;
+        this.clientSecret = opts?.clientSecret;
+    }
+    async getViewerId() {
+        if (this.viewerId)
+            return this.viewerId;
+        try {
+            const data = await this.gql(`query { viewer { id } }`);
+            this.viewerId = data.viewer.id;
+            return this.viewerId;
+        }
+        catch {
+            return null;
+        }
+    }
+    /** Refresh the token if it's expired (or about to expire in 60s) */
+    async ensureValidToken() {
+        if (!this.refreshToken || !this.clientId || !this.clientSecret)
+            return;
+        if (!this.expiresAt)
+            return;
+        const bufferMs = 60_000; // refresh 60s before expiry
+        if (Date.now() < this.expiresAt - bufferMs)
+            return;
+        const result = await refreshLinearToken(this.clientId, this.clientSecret, this.refreshToken);
+        this.accessToken = result.access_token;
+        if (result.refresh_token)
+            this.refreshToken = result.refresh_token;
+        this.expiresAt = Date.now() + result.expires_in * 1000;
+        // Persist refreshed token back to auth profile store
+        this.persistToken();
+    }
+    persistToken() {
+        try {
+            const raw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+            const store = JSON.parse(raw);
+            if (store.profiles?.["linear:default"]) {
+                store.profiles["linear:default"].accessToken = this.accessToken;
+                store.profiles["linear:default"].access = this.accessToken;
+                if (this.refreshToken) {
+                    store.profiles["linear:default"].refreshToken = this.refreshToken;
+                    store.profiles["linear:default"].refresh = this.refreshToken;
+                }
+                if (this.expiresAt) {
+                    store.profiles["linear:default"].expiresAt = this.expiresAt;
+                    store.profiles["linear:default"].expires = this.expiresAt;
+                }
+                writeFileSync(AUTH_PROFILES_PATH, JSON.stringify(store, null, 2), "utf8");
+            }
+        }
+        catch {
+            // Best-effort persistence
+        }
+    }
+    authHeader() {
+        // OAuth tokens (which have a refreshToken) require Bearer prefix;
+        // personal API keys do not.
+        return this.refreshToken ? `Bearer ${this.accessToken}` : this.accessToken;
+    }
+    async gql(query, variables, extraHeaders) {
+        await this.ensureValidToken();
+        const headers = {
+            "Content-Type": "application/json",
+            Authorization: this.authHeader(),
+            ...extraHeaders,
+        };
+        const res = await withResilience(() => fetch(LINEAR_GRAPHQL_URL, {
+            method: "POST",
+            headers,
+            body: JSON.stringify({ query, variables }),
+        }));
+        // If 401, try refreshing token once (outside resilience — own retry semantics)
+        if (res.status === 401 && this.refreshToken && this.clientId && this.clientSecret) {
+            this.expiresAt = 0; // force refresh
+            await this.ensureValidToken();
+            const retryHeaders = {
+                "Content-Type": "application/json",
+                Authorization: this.authHeader(),
+                ...extraHeaders,
+            };
+            const retryRes = await fetch(LINEAR_GRAPHQL_URL, {
+                method: "POST",
+                headers: retryHeaders,
+                body: JSON.stringify({ query, variables }),
+            });
+            if (!retryRes.ok) {
+                const text = await retryRes.text();
+                throw new Error(`Linear API authentication failed (${retryRes.status}). Your token may have expired. Run: openclaw openclaw-linear auth`);
+            }
+            const payload = await retryRes.json();
+            if (payload.errors?.length && !payload.data) {
+                throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`);
+            }
+            return payload.data;
+        }
+        if (!res.ok) {
+            const text = await res.text();
+            throw new Error(`Linear API ${res.status}: ${text}`);
+        }
+        const payload = await res.json();
+        if (payload.errors?.length && !payload.data) {
+            throw new Error(`Linear GraphQL: ${JSON.stringify(payload.errors)}`);
+        }
+        return payload.data;
+    }
+    async emitActivity(agentSessionId, content) {
+        await this.gql(`mutation AgentActivityCreate($input: AgentActivityCreateInput!) {
+        agentActivityCreate(input: $input) {
+          success
+        }
+      }`, { input: { agentSessionId, content } });
+    }
+    async updateSession(agentSessionId, input) {
+        await this.gql(`mutation AgentSessionUpdate($id: String!, $input: AgentSessionUpdateInput!) {
+        agentSessionUpdate(id: $id, input: $input) {
+          success
+        }
+      }`, { id: agentSessionId, input });
+    }
+    async createReaction(commentId, emoji) {
+        try {
+            const data = await this.gql(`mutation ReactionCreate($input: ReactionCreateInput!) {
+          reactionCreate(input: $input) {
+            success
+          }
+        }`, { input: { commentId, emoji } });
+            return data.reactionCreate.success;
+        }
+        catch {
+            return false;
+        }
+    }
+    async createSessionOnIssue(issueId) {
+        try {
+            const data = await this.gql(`mutation AgentSessionCreateOnIssue($input: AgentSessionCreateOnIssue!) {
+          agentSessionCreateOnIssue(input: $input) {
+            success
+            agentSession { id }
+          }
+        }`, { input: { issueId } });
+            const id = data.agentSessionCreateOnIssue.agentSession?.id ?? null;
+            if (!id)
+                return { sessionId: null, error: `success=${data.agentSessionCreateOnIssue.success} but no session ID` };
+            return { sessionId: id };
+        }
+        catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            return { sessionId: null, error: msg };
+        }
+    }
+    async createComment(issueId, body, opts) {
+        const input = { issueId, body };
+        if (opts?.createAsUser)
+            input.createAsUser = opts.createAsUser;
+        if (opts?.displayIconUrl)
+            input.displayIconUrl = opts.displayIconUrl;
+        const data = await this.gql(`mutation CommentCreate($input: CommentCreateInput!) {
+        commentCreate(input: $input) {
+          success
+          comment { id }
+        }
+      }`, { input });
+        return data.commentCreate.comment.id;
+    }
+    async getIssueDetails(issueId) {
+        const data = await this.gql(`query Issue($id: String!) {
+        issue(id: $id) {
+          id
+          identifier
+          title
+          description
+          estimate
+          state { name type }
+          creator { name email }
+          assignee { name }
+          labels { nodes { id name } }
+          team { id key name issueEstimationType }
+          comments(last: 10) {
+            nodes {
+              body
+              user { name }
+              createdAt
+            }
+          }
+          project { id name }
+          parent { id identifier }
+          relations { nodes { type relatedIssue { id identifier title } } }
+        }
+      }`, { id: issueId });
+        return data.issue;
+    }
+    async updateIssue(issueId, input) {
+        const data = await this.gql(`mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
+        issueUpdate(id: $id, input: $input) {
+          success
+        }
+      }`, { id: issueId, input });
+        return data.issueUpdate.success;
+    }
+    async getTeamLabels(teamId) {
+        const data = await this.gql(`query TeamLabels($id: String!) {
+        team(id: $id) {
+          labels { nodes { id name } }
+        }
+      }`, { id: teamId });
+        return data.team.labels.nodes;
+    }
+    async getTeams() {
+        const data = await this.gql(`query { teams { nodes { id name key } } }`);
+        return data.teams.nodes;
+    }
+    async createLabel(teamId, name, opts) {
+        const input = { teamId, name };
+        if (opts?.color)
+            input.color = opts.color;
+        if (opts?.description)
+            input.description = opts.description;
+        const data = await this.gql(`mutation CreateLabel($input: IssueLabelCreateInput!) {
+        issueLabelCreate(input: $input) {
+          success
+          issueLabel { id name }
+        }
+      }`, { input });
+        if (!data.issueLabelCreate.success) {
+            throw new Error(`Failed to create label "${name}"`);
+        }
+        return data.issueLabelCreate.issueLabel;
+    }
+    // ---------------------------------------------------------------------------
+    // Planning methods
+    // ---------------------------------------------------------------------------
+    async createIssue(input) {
+        // Sub-issues require the GraphQL-Features header
+        const extra = input.parentId ? { "GraphQL-Features": "sub_issues" } : undefined;
+        const data = await this.gql(`mutation IssueCreate($input: IssueCreateInput!) {
+        issueCreate(input: $input) {
+          success
+          issue { id identifier }
+        }
+      }`, { input }, extra);
+        return data.issueCreate.issue;
+    }
+    async createIssueRelation(input) {
+        const data = await this.gql(`mutation IssueRelationCreate($input: IssueRelationCreateInput!) {
+        issueRelationCreate(input: $input) {
+          success
+          issueRelation { id }
+        }
+      }`, { input });
+        return data.issueRelationCreate.issueRelation;
+    }
+    async getProject(projectId) {
+        const data = await this.gql(`query Project($id: String!) {
+        project(id: $id) {
+          id
+          name
+          description
+          state
+          teams { nodes { id name } }
+        }
+      }`, { id: projectId });
+        return data.project;
+    }
+    async getProjectIssues(projectId) {
+        const data = await this.gql(`query ProjectIssues($id: String!) {
+        project(id: $id) {
+          issues {
+            nodes {
+              id
+              identifier
+              title
+              description
+              estimate
+              priority
+              state { name type }
+              parent { id identifier }
+              labels { nodes { id name } }
+              relations { nodes { type relatedIssue { id identifier title } } }
+            }
+          }
+        }
+      }`, { id: projectId });
+        return data.project.issues.nodes;
+    }
+    async getTeamStates(teamId) {
+        const data = await this.gql(`query TeamStates($id: String!) {
+        team(id: $id) {
+          states { nodes { id name type } }
+        }
+      }`, { id: teamId });
+        return data.team.states.nodes;
+    }
+    async updateIssueExtended(issueId, input) {
+        const data = await this.gql(`mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {
+        issueUpdate(id: $id, input: $input) {
+          success
+        }
+      }`, { id: issueId, input });
+        return data.issueUpdate.success;
+    }
+    async getAppNotifications(count = 5) {
+        const data = await this.gql(`query Notifications($first: Int!) {
+        notifications(first: $first, orderBy: createdAt) {
+          nodes {
+            id
+            type
+            createdAt
+            ... on IssueNotification {
+              issue { id identifier title }
+              comment { id body }
+            }
+          }
+        }
+      }`, { first: count });
+        return data.notifications.nodes;
+    }
+    // ---------------------------------------------------------------------------
+    // Webhook management
+    // ---------------------------------------------------------------------------
+    async listWebhooks() {
+        const data = await this.gql(`query Webhooks {
+        webhooks {
+          nodes {
+            id
+            label
+            url
+            enabled
+            resourceTypes
+            allPublicTeams
+            team { id name }
+            createdAt
+          }
+        }
+      }`);
+        return data.webhooks.nodes;
+    }
+    async createWebhook(input) {
+        const data = await this.gql(`mutation WebhookCreate($input: WebhookCreateInput!) {
+        webhookCreate(input: $input) {
+          success
+          webhook { id enabled }
+        }
+      }`, { input });
+        return data.webhookCreate.webhook;
+    }
+    async updateWebhook(webhookId, input) {
+        const data = await this.gql(`mutation WebhookUpdate($id: String!, $input: WebhookUpdateInput!) {
+        webhookUpdate(id: $id, input: $input) {
+          success
+        }
+      }`, { id: webhookId, input });
+        return data.webhookUpdate.success;
+    }
+    async deleteWebhook(webhookId) {
+        const data = await this.gql(`mutation WebhookDelete($id: String!) {
+        webhookDelete(id: $id) {
+          success
+        }
+      }`, { id: webhookId });
+        return data.webhookDelete.success;
+    }
+    /**
+     * Get repository suggestions from Linear for an issue.
+     * Uses Linear's ML to rank candidate repos by relevance to the issue.
+     */
+    async getRepositorySuggestions(issueId, agentSessionId, candidates) {
+        if (candidates.length === 0)
+            return [];
+        try {
+            const data = await this.gql(`query RepoSuggestions($issueId: String!, $agentSessionId: String!, $candidateRepositories: [CandidateRepository!]!) {
+          issueRepositorySuggestions(issueId: $issueId, agentSessionId: $agentSessionId, candidateRepositories: $candidateRepositories) {
+            suggestions {
+              repositoryFullName
+              hostname
+              confidence
+            }
+          }
+        }`, { issueId, agentSessionId, candidateRepositories: candidates });
+            return data.issueRepositorySuggestions?.suggestions ?? [];
+        }
+        catch {
+            // Best-effort — if the API doesn't support this or fails, return empty
+            return [];
+        }
+    }
+}
+// ---------------------------------------------------------------------------
+// Proactive token refresh (standalone, no API call required)
+// ---------------------------------------------------------------------------
+const PROACTIVE_BUFFER_MS = 3_600_000; // 1 hour before expiry
+/**
+ * Proactively refresh the Linear OAuth token if it's expired or about to expire.
+ * Returns true if refreshed, false if skipped (not needed or can't refresh).
+ *
+ * This is a standalone function that can be called from a timer without making
+ * a Linear API request. It reads/writes auth-profiles.json directly.
+ */
+export async function refreshTokenProactively(pluginConfig) {
+    // 1. Read auth-profiles.json, get linear:default profile
+    let store;
+    try {
+        const raw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+        store = JSON.parse(raw);
+    }
+    catch {
+        return { refreshed: false, reason: "auth-profiles.json not readable" };
+    }
+    const profile = store?.profiles?.["linear:default"];
+    if (!profile) {
+        return { refreshed: false, reason: "no linear:default profile found" };
+    }
+    // 2. Check if token is expired or will expire within 1 hour
+    const expiresAt = profile.expiresAt ?? profile.expires;
+    if (typeof expiresAt === "number" && Date.now() < expiresAt - PROACTIVE_BUFFER_MS) {
+        return { refreshed: false, reason: "token still valid" };
+    }
+    // 3. Resolve credentials
+    const clientId = pluginConfig?.clientId ?? process.env.LINEAR_CLIENT_ID;
+    const clientSecret = pluginConfig?.clientSecret ?? process.env.LINEAR_CLIENT_SECRET;
+    const refreshToken = profile.refreshToken ?? profile.refresh;
+    if (!clientId || !clientSecret || !refreshToken) {
+        return { refreshed: false, reason: "missing credentials (clientId, clientSecret, or refreshToken)" };
+    }
+    // 4. Refresh the token
+    const result = await refreshLinearToken(clientId, clientSecret, refreshToken);
+    // 5. Persist updated tokens back to auth-profiles.json (same pattern as persistToken())
+    const newAccessToken = result.access_token;
+    const newRefreshToken = result.refresh_token ?? refreshToken;
+    const newExpiresAt = Date.now() + result.expires_in * 1000;
+    try {
+        // Re-read to avoid clobbering concurrent writes
+        const freshRaw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+        const freshStore = JSON.parse(freshRaw);
+        if (freshStore.profiles?.["linear:default"]) {
+            freshStore.profiles["linear:default"].accessToken = newAccessToken;
+            freshStore.profiles["linear:default"].access = newAccessToken;
+            freshStore.profiles["linear:default"].refreshToken = newRefreshToken;
+            freshStore.profiles["linear:default"].refresh = newRefreshToken;
+            freshStore.profiles["linear:default"].expiresAt = newExpiresAt;
+            freshStore.profiles["linear:default"].expires = newExpiresAt;
+            writeFileSync(AUTH_PROFILES_PATH, JSON.stringify(freshStore, null, 2), "utf8");
+        }
+    }
+    catch {
+        // Best-effort persistence — token was refreshed even if write fails
+    }
+    return { refreshed: true, reason: "token refreshed successfully" };
+}

--- a/dist/src/api/oauth-callback.js
+++ b/dist/src/api/oauth-callback.js
@@ -1,0 +1,113 @@
+import { writeFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+const LINEAR_OAUTH_TOKEN_URL = "https://api.linear.app/oauth/token";
+const AUTH_PROFILES_PATH = join(homedir(), ".openclaw", "auth-profiles.json");
+export async function handleOAuthCallback(api, req, res) {
+    const url = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`);
+    const code = url.searchParams.get("code");
+    const error = url.searchParams.get("error");
+    if (error) {
+        res.statusCode = 400;
+        res.end(`OAuth error: ${error} — ${url.searchParams.get("error_description") ?? ""}`);
+        return;
+    }
+    if (!code) {
+        res.statusCode = 400;
+        res.end("Missing authorization code");
+        return;
+    }
+    // Read OAuth client credentials from plugin config first (the canonical
+    // location), then env vars as a fallback. The gateway's systemd unit does
+    // not set LINEAR_CLIENT_ID / LINEAR_CLIENT_SECRET, so requiring them via
+    // env was a regression that made the HTTP callback unusable.
+    const pluginConfig = api.pluginConfig;
+    const clientId = pluginConfig?.clientId ??
+        process.env.LINEAR_CLIENT_ID;
+    const clientSecret = pluginConfig?.clientSecret ??
+        process.env.LINEAR_CLIENT_SECRET;
+    // The redirect_uri sent in the token-exchange request MUST match the one
+    // used in the authorize step. Resolution order:
+    //   1. explicit plugin config override
+    //   2. explicit env var override
+    //   3. derive from inbound request headers (canonical for OAuth callbacks
+    //      behind a reverse proxy / tunnel — uses x-forwarded-proto + host)
+    //   4. localhost fallback (only when the request has no host header)
+    const gatewayPort = process.env.OPENCLAW_GATEWAY_PORT ?? "18789";
+    const requestHost = req.headers.host;
+    const requestProto = req.headers["x-forwarded-proto"] ?? "https";
+    const redirectUri = pluginConfig?.redirectUri ??
+        process.env.LINEAR_REDIRECT_URI ??
+        (requestHost
+            ? `${requestProto}://${requestHost}/linear/oauth/callback`
+            : `http://localhost:${gatewayPort}/linear/oauth/callback`);
+    if (!clientId || !clientSecret) {
+        res.statusCode = 500;
+        res.end("Linear OAuth callback: clientId/clientSecret missing from plugin config and env");
+        return;
+    }
+    api.logger.info("Linear OAuth: exchanging authorization code for token...");
+    try {
+        const tokenRes = await fetch(LINEAR_OAUTH_TOKEN_URL, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/x-www-form-urlencoded",
+                Accept: "application/json",
+            },
+            body: new URLSearchParams({
+                grant_type: "authorization_code",
+                code,
+                client_id: clientId,
+                client_secret: clientSecret,
+                redirect_uri: redirectUri,
+            }),
+        });
+        if (!tokenRes.ok) {
+            const errText = await tokenRes.text();
+            api.logger.error(`Linear OAuth token exchange failed: ${errText}`);
+            res.statusCode = 502;
+            res.end(`Token exchange failed: ${errText}`);
+            return;
+        }
+        const tokens = await tokenRes.json();
+        api.logger.info(`Linear OAuth: token received (expires_in: ${tokens.expires_in}s, scopes: ${tokens.scope})`);
+        // Store in auth profile store
+        let store = { version: 1, profiles: {} };
+        try {
+            const raw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+            store = JSON.parse(raw);
+        }
+        catch {
+            // Fresh store
+        }
+        store.profiles = store.profiles ?? {};
+        store.profiles["linear:default"] = {
+            type: "oauth",
+            provider: "linear",
+            accessToken: tokens.access_token,
+            access: tokens.access_token,
+            refreshToken: tokens.refresh_token ?? null,
+            refresh: tokens.refresh_token ?? null,
+            expiresAt: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
+            expires: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
+            scope: tokens.scope,
+        };
+        writeFileSync(AUTH_PROFILES_PATH, JSON.stringify(store, null, 2), "utf8");
+        api.logger.info("Linear OAuth: token stored in auth profile store");
+        res.statusCode = 200;
+        res.setHeader("Content-Type", "text/html");
+        res.end(`
+      <html><body style="font-family: system-ui; max-width: 600px; margin: 80px auto; text-align: center;">
+        <h1>Linear OAuth Complete</h1>
+        <p>Access token stored. Scopes: <code>${tokens.scope ?? "unknown"}</code></p>
+        <p>The Linear agent pipeline is now active. You can close this tab.</p>
+        <p style="color: #888; font-size: 0.9em;">Restart the gateway to pick up the new token.</p>
+      </body></html>
+    `);
+    }
+    catch (err) {
+        api.logger.error(`Linear OAuth error: ${err}`);
+        res.statusCode = 500;
+        res.end(`OAuth error: ${String(err)}`);
+    }
+}

--- a/dist/src/gateway/dispatch-methods.js
+++ b/dist/src/gateway/dispatch-methods.js
@@ -1,0 +1,193 @@
+/**
+ * dispatch-methods.ts — Gateway RPC methods for dispatch operations.
+ *
+ * Registers methods on the OpenClaw gateway that allow clients (UI, CLI, other
+ * plugins) to inspect and manage the dispatch pipeline via the standard
+ * gateway request/respond protocol.
+ *
+ * Methods:
+ *   dispatch.list      — List active + completed dispatches (filterable)
+ *   dispatch.get       — Full details for a single dispatch
+ *   dispatch.retry     — Re-dispatch a stuck issue
+ *   dispatch.escalate  — Force a working/auditing dispatch into stuck
+ *   dispatch.cancel    — Remove an active dispatch entirely
+ *   dispatch.stats     — Aggregate counts by status and tier
+ */
+import { readDispatchState, getActiveDispatch, listActiveDispatches, transitionDispatch, removeActiveDispatch, registerDispatch, TransitionError, } from "../pipeline/dispatch-state.js";
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function ok(data = {}) {
+    return { ok: true, ...data };
+}
+function fail(error) {
+    return { ok: false, error };
+}
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+export function registerDispatchMethods(api) {
+    const pluginConfig = api.pluginConfig;
+    const statePath = pluginConfig?.dispatchStatePath;
+    // ---- dispatch.list -------------------------------------------------------
+    api.registerGatewayMethod("dispatch.list", async ({ params, respond }) => {
+        try {
+            const statusFilter = params.status;
+            const tierFilter = params.tier;
+            const state = await readDispatchState(statePath);
+            let active = listActiveDispatches(state);
+            if (statusFilter) {
+                active = active.filter((d) => d.status === statusFilter);
+            }
+            if (tierFilter) {
+                active = active.filter((d) => d.tier === tierFilter);
+            }
+            const completed = Object.values(state.dispatches.completed);
+            respond(true, ok({ active, completed }));
+        }
+        catch (err) {
+            respond(true, fail(err.message ?? String(err)));
+        }
+    });
+    // ---- dispatch.get --------------------------------------------------------
+    api.registerGatewayMethod("dispatch.get", async ({ params, respond }) => {
+        try {
+            const identifier = params.identifier;
+            if (!identifier) {
+                respond(true, fail("Missing required param: identifier"));
+                return;
+            }
+            const state = await readDispatchState(statePath);
+            const active = getActiveDispatch(state, identifier);
+            if (active) {
+                respond(true, ok({ dispatch: active, source: "active" }));
+                return;
+            }
+            const completed = state.dispatches.completed[identifier];
+            if (completed) {
+                respond(true, ok({ dispatch: completed, source: "completed" }));
+                return;
+            }
+            respond(true, fail(`No dispatch found for identifier: ${identifier}`));
+        }
+        catch (err) {
+            respond(true, fail(err.message ?? String(err)));
+        }
+    });
+    // ---- dispatch.retry ------------------------------------------------------
+    // Stuck dispatches are terminal in VALID_TRANSITIONS, so we cannot use
+    // transitionDispatch. Instead, remove the active dispatch and re-register
+    // it with status reset to "dispatched" and an incremented attempt counter.
+    api.registerGatewayMethod("dispatch.retry", async ({ params, respond }) => {
+        try {
+            const identifier = params.identifier;
+            if (!identifier) {
+                respond(true, fail("Missing required param: identifier"));
+                return;
+            }
+            const state = await readDispatchState(statePath);
+            const dispatch = getActiveDispatch(state, identifier);
+            if (!dispatch) {
+                respond(true, fail(`No active dispatch for identifier: ${identifier}`));
+                return;
+            }
+            if (dispatch.status !== "stuck") {
+                respond(true, fail(`Cannot retry dispatch in status "${dispatch.status}" — only "stuck" dispatches can be retried`));
+                return;
+            }
+            // Capture current state, remove, then re-register with reset status
+            const retryDispatch = {
+                ...dispatch,
+                status: "dispatched",
+                attempt: dispatch.attempt + 1,
+                stuckReason: undefined,
+                workerSessionKey: undefined,
+                auditSessionKey: undefined,
+            };
+            await removeActiveDispatch(identifier, statePath);
+            await registerDispatch(identifier, retryDispatch, statePath);
+            api.logger.info(`dispatch.retry: ${identifier} re-dispatched (attempt ${retryDispatch.attempt})`);
+            respond(true, ok({ dispatch: retryDispatch }));
+        }
+        catch (err) {
+            respond(true, fail(err.message ?? String(err)));
+        }
+    });
+    // ---- dispatch.escalate ---------------------------------------------------
+    api.registerGatewayMethod("dispatch.escalate", async ({ params, respond }) => {
+        try {
+            const identifier = params.identifier;
+            if (!identifier) {
+                respond(true, fail("Missing required param: identifier"));
+                return;
+            }
+            const reason = params.reason || "Manually escalated via gateway";
+            const state = await readDispatchState(statePath);
+            const dispatch = getActiveDispatch(state, identifier);
+            if (!dispatch) {
+                respond(true, fail(`No active dispatch for identifier: ${identifier}`));
+                return;
+            }
+            if (dispatch.status !== "working" && dispatch.status !== "auditing") {
+                respond(true, fail(`Cannot escalate dispatch in status "${dispatch.status}" — only "working" or "auditing" dispatches can be escalated`));
+                return;
+            }
+            const updated = await transitionDispatch(identifier, dispatch.status, "stuck", { stuckReason: reason }, statePath);
+            api.logger.info(`dispatch.escalate: ${identifier} escalated to stuck (was ${dispatch.status}, reason: ${reason})`);
+            respond(true, ok({ dispatch: updated }));
+        }
+        catch (err) {
+            if (err instanceof TransitionError) {
+                respond(true, fail(`Transition conflict: ${err.message}`));
+                return;
+            }
+            respond(true, fail(err.message ?? String(err)));
+        }
+    });
+    // ---- dispatch.cancel -----------------------------------------------------
+    api.registerGatewayMethod("dispatch.cancel", async ({ params, respond }) => {
+        try {
+            const identifier = params.identifier;
+            if (!identifier) {
+                respond(true, fail("Missing required param: identifier"));
+                return;
+            }
+            const state = await readDispatchState(statePath);
+            const dispatch = getActiveDispatch(state, identifier);
+            if (!dispatch) {
+                respond(true, fail(`No active dispatch for identifier: ${identifier}`));
+                return;
+            }
+            await removeActiveDispatch(identifier, statePath);
+            api.logger.info(`dispatch.cancel: ${identifier} removed (was ${dispatch.status})`);
+            respond(true, ok({ cancelled: identifier, previousStatus: dispatch.status }));
+        }
+        catch (err) {
+            respond(true, fail(err.message ?? String(err)));
+        }
+    });
+    // ---- dispatch.stats ------------------------------------------------------
+    api.registerGatewayMethod("dispatch.stats", async ({ params, respond }) => {
+        try {
+            const state = await readDispatchState(statePath);
+            const active = listActiveDispatches(state);
+            const byStatus = {};
+            const byTier = {};
+            for (const d of active) {
+                byStatus[d.status] = (byStatus[d.status] ?? 0) + 1;
+                byTier[d.tier] = (byTier[d.tier] ?? 0) + 1;
+            }
+            const completedCount = Object.keys(state.dispatches.completed).length;
+            respond(true, ok({
+                activeCount: active.length,
+                completedCount,
+                byStatus,
+                byTier,
+            }));
+        }
+        catch (err) {
+            respond(true, fail(err.message ?? String(err)));
+        }
+    });
+    api.logger.info("Dispatch gateway methods registered (dispatch.list, dispatch.get, dispatch.retry, dispatch.escalate, dispatch.cancel, dispatch.stats)");
+}

--- a/dist/src/infra/cli.js
+++ b/dist/src/infra/cli.js
@@ -1,0 +1,1115 @@
+import { createInterface } from "node:readline";
+import { exec } from "node:child_process";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { resolveLinearToken, LinearAgentApi, AUTH_PROFILES_PATH, LINEAR_GRAPHQL_URL } from "../api/linear-api.js";
+import { validateRepoPath } from "./multi-repo.js";
+import { LINEAR_OAUTH_AUTH_URL, LINEAR_OAUTH_TOKEN_URL, LINEAR_AGENT_SCOPES } from "../api/auth.js";
+import { listWorktrees } from "./codex-worktree.js";
+import { loadPrompts, clearPromptCache } from "../pipeline/pipeline.js";
+import { PROFILES_PATH, createAgentProfilesFile, loadAgentProfiles } from "./shared-profiles.js";
+import { formatMessage, parseNotificationsConfig, sendToTarget, } from "./notify.js";
+function prompt(question) {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    return new Promise((resolve) => {
+        rl.question(question, (answer) => {
+            rl.close();
+            resolve(answer.trim());
+        });
+    });
+}
+function openBrowser(url) {
+    const cmd = process.platform === "darwin" ? "open" : "xdg-open";
+    exec(`${cmd} ${JSON.stringify(url)}`, () => { });
+}
+export function registerCli(program, api) {
+    const linear = program
+        .command("openclaw-linear")
+        .description("Linear plugin — auth and status");
+    // --- openclaw openclaw-linear auth ---
+    linear
+        .command("auth")
+        .description("Run Linear OAuth flow to authorize the agent")
+        .action(async () => {
+        const pluginConfig = api.pluginConfig;
+        const clientId = pluginConfig?.clientId ?? process.env.LINEAR_CLIENT_ID;
+        const clientSecret = pluginConfig?.clientSecret ?? process.env.LINEAR_CLIENT_SECRET;
+        if (!clientId || !clientSecret) {
+            console.error("Error: Linear client ID and secret must be configured.");
+            console.error("Set LINEAR_CLIENT_ID and LINEAR_CLIENT_SECRET env vars, or add clientId/clientSecret to plugin config.");
+            process.exitCode = 1;
+            return;
+        }
+        const gatewayPort = process.env.OPENCLAW_GATEWAY_PORT ?? "18789";
+        const redirectUri = pluginConfig?.redirectUri
+            ?? process.env.LINEAR_REDIRECT_URI
+            ?? `http://localhost:${gatewayPort}/linear/oauth/callback`;
+        const state = Math.random().toString(36).substring(7);
+        const authUrl = `${LINEAR_OAUTH_AUTH_URL}?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=${encodeURIComponent(LINEAR_AGENT_SCOPES)}&state=${state}&actor=app`;
+        console.log("\nOpening Linear OAuth authorization page...\n");
+        console.log(`  ${authUrl}\n`);
+        openBrowser(authUrl);
+        const code = await prompt("Paste the authorization code from Linear: ");
+        if (!code) {
+            console.error("No code provided. Aborting.");
+            process.exitCode = 1;
+            return;
+        }
+        console.log("Exchanging code for token...");
+        const response = await fetch(LINEAR_OAUTH_TOKEN_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
+            body: new URLSearchParams({
+                grant_type: "authorization_code",
+                code,
+                client_id: clientId,
+                client_secret: clientSecret,
+                redirect_uri: redirectUri,
+            }),
+        });
+        if (!response.ok) {
+            const error = await response.text();
+            console.error(`OAuth token exchange failed (${response.status}): ${error}`);
+            process.exitCode = 1;
+            return;
+        }
+        const tokens = await response.json();
+        // Store in auth profile store
+        let store = { version: 1, profiles: {} };
+        try {
+            const raw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+            store = JSON.parse(raw);
+        }
+        catch {
+            // Fresh store
+        }
+        store.profiles = store.profiles ?? {};
+        store.profiles["linear:default"] = {
+            type: "oauth",
+            provider: "linear",
+            accessToken: tokens.access_token,
+            access: tokens.access_token,
+            refreshToken: tokens.refresh_token ?? null,
+            refresh: tokens.refresh_token ?? null,
+            expiresAt: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
+            expires: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
+            scope: tokens.scope,
+        };
+        writeFileSync(AUTH_PROFILES_PATH, JSON.stringify(store, null, 2), "utf8");
+        const expiresIn = tokens.expires_in ? `${Math.round(tokens.expires_in / 3600)}h` : "unknown";
+        console.log(`\nAuthorized! Token stored in auth profile store.`);
+        console.log(`  Scopes:  ${tokens.scope ?? "unknown"}`);
+        console.log(`  Expires: ${expiresIn}`);
+        console.log(`\nRestart the gateway to pick up the new token.`);
+    });
+    // --- openclaw openclaw-linear status ---
+    linear
+        .command("status")
+        .description("Show current Linear auth and connection status")
+        .action(async () => {
+        const pluginConfig = api.pluginConfig;
+        const tokenInfo = resolveLinearToken(pluginConfig);
+        console.log("\nLinear Auth Status");
+        console.log("─".repeat(40));
+        console.log(`  Source:        ${tokenInfo.source}`);
+        if (!tokenInfo.accessToken) {
+            console.log(`  Token:         not found`);
+            console.log(`\nRun "openclaw openclaw-linear auth" to authorize.`);
+            return;
+        }
+        console.log(`  Token:         ${tokenInfo.accessToken.slice(0, 12)}...`);
+        console.log(`  Refresh token: ${tokenInfo.refreshToken ? "present" : "none"}`);
+        if (tokenInfo.expiresAt) {
+            const remaining = tokenInfo.expiresAt - Date.now();
+            if (remaining <= 0) {
+                console.log(`  Expires:       EXPIRED`);
+            }
+            else {
+                const hours = Math.floor(remaining / 3_600_000);
+                const mins = Math.floor((remaining % 3_600_000) / 60_000);
+                console.log(`  Expires:       ${hours}h ${mins}m`);
+            }
+        }
+        else {
+            console.log(`  Expires:       unknown (no expiry set)`);
+        }
+        // Try reading scope from profile
+        try {
+            const raw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+            const store = JSON.parse(raw);
+            const scope = store?.profiles?.["linear:default"]?.scope;
+            if (scope)
+                console.log(`  Scopes:        ${scope}`);
+        }
+        catch { }
+        // Verify token with API call
+        console.log("\nConnection Test");
+        console.log("─".repeat(40));
+        try {
+            const authHeader = tokenInfo.refreshToken
+                ? `Bearer ${tokenInfo.accessToken}`
+                : tokenInfo.accessToken;
+            const res = await fetch(LINEAR_GRAPHQL_URL, {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: authHeader,
+                },
+                body: JSON.stringify({
+                    query: `{ viewer { id name email } organization { name urlKey } }`,
+                }),
+            });
+            if (!res.ok) {
+                console.log(`  API response:  ${res.status} ${res.statusText}`);
+                return;
+            }
+            const payload = await res.json();
+            if (payload.errors?.length) {
+                console.log(`  API error:     ${payload.errors[0].message}`);
+                return;
+            }
+            const { viewer, organization } = payload.data;
+            console.log(`  API:           connected`);
+            console.log(`  User:          ${viewer.name} (${viewer.email})`);
+            console.log(`  Workspace:     ${organization.name} (${organization.urlKey})`);
+        }
+        catch (err) {
+            console.log(`  API:           failed — ${err instanceof Error ? err.message : String(err)}`);
+        }
+        console.log();
+    });
+    // --- interactive profile creation helper ---
+    async function createProfileInteractive() {
+        const name = await prompt("  Agent name (lowercase, no spaces — e.g. bobbin): ");
+        if (!name) {
+            console.log("  Skipped.\n");
+            return;
+        }
+        const agentId = name.toLowerCase().replace(/[^a-z0-9-]/g, "-").replace(/-+/g, "-").replace(/^-|-$/g, "");
+        if (!agentId) {
+            console.log("  Invalid name. Skipped.\n");
+            return;
+        }
+        const labelDefault = agentId.charAt(0).toUpperCase() + agentId.slice(1);
+        const labelInput = await prompt(`  Display label [${labelDefault}]: `);
+        const label = labelInput || labelDefault;
+        const aliasInput = await prompt(`  Additional @mention aliases (comma-separated, or blank): `);
+        const extraAliases = aliasInput
+            ? aliasInput.split(",").map(a => a.trim().toLowerCase()).filter(Boolean)
+            : [];
+        const mentionAliases = [agentId, ...extraAliases.filter(a => a !== agentId)];
+        try {
+            createAgentProfilesFile({ agentId, label, mentionAliases });
+            console.log(`\n  ✓ Created ${PROFILES_PATH}`);
+            console.log(`    Agent: ${agentId} (${label})`);
+            console.log(`    Aliases: ${mentionAliases.map(a => "@" + a).join(", ")}`);
+            console.log(`    Default: yes`);
+        }
+        catch (err) {
+            console.log(`\n  ✗ Failed to create agent-profiles.json: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+    // --- openclaw openclaw-linear setup ---
+    linear
+        .command("setup")
+        .description("Guided first-time setup — creates agent profile, checks auth, provisions webhook")
+        .action(async () => {
+        const pluginConfig = api.pluginConfig;
+        console.log("\nLinear Plugin Setup");
+        console.log("═".repeat(50));
+        // ---------------------------------------------------------------
+        // Step 1: Agent Profile
+        // ---------------------------------------------------------------
+        console.log("\nStep 1: Agent Profile");
+        console.log("─".repeat(50));
+        if (existsSync(PROFILES_PATH)) {
+            const profiles = loadAgentProfiles();
+            const count = Object.keys(profiles).length;
+            if (count > 0) {
+                const names = Object.entries(profiles)
+                    .map(([id, p]) => `${id}${p.isDefault ? " (default)" : ""}`)
+                    .join(", ");
+                console.log(`  ✓ agent-profiles.json found (${count} agent${count > 1 ? "s" : ""}: ${names})`);
+            }
+            else {
+                console.log("  ⚠ agent-profiles.json exists but has no agents.");
+                const fix = await prompt("  Overwrite with a new profile? [Y/n]: ");
+                if (fix.toLowerCase() === "n") {
+                    console.log("  Skipped. Fix the file manually and re-run setup.\n");
+                }
+                else {
+                    await createProfileInteractive();
+                }
+            }
+        }
+        else {
+            console.log("  No agent-profiles.json found — let's create one!\n");
+            console.log("  Your agent needs a name so Linear users can @mention it.");
+            console.log("  Example: if your agent is called \"bobbin\", users type @bobbin in comments.\n");
+            await createProfileInteractive();
+        }
+        // ---------------------------------------------------------------
+        // Step 2: Authentication
+        // ---------------------------------------------------------------
+        console.log("\nStep 2: Authentication");
+        console.log("─".repeat(50));
+        const tokenInfo = resolveLinearToken(pluginConfig);
+        if (tokenInfo.accessToken) {
+            // Verify the token works
+            try {
+                const authHeader = tokenInfo.refreshToken
+                    ? `Bearer ${tokenInfo.accessToken}`
+                    : tokenInfo.accessToken;
+                const res = await fetch(LINEAR_GRAPHQL_URL, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json", Authorization: authHeader },
+                    body: JSON.stringify({ query: `{ viewer { name } organization { name } }` }),
+                });
+                if (res.ok) {
+                    const payload = await res.json();
+                    if (payload.data?.viewer) {
+                        console.log(`  ✓ Authenticated as ${payload.data.viewer.name} (${payload.data.organization.name})`);
+                    }
+                    else {
+                        console.log(`  ⚠ Token found but API returned errors. Run: openclaw openclaw-linear auth`);
+                    }
+                }
+                else {
+                    console.log(`  ⚠ Token found but API returned ${res.status}. Run: openclaw openclaw-linear auth`);
+                }
+            }
+            catch {
+                console.log(`  ⚠ Token found but API unreachable. Check network and retry.`);
+            }
+        }
+        else {
+            console.log("  No Linear token found.\n");
+            const doAuth = await prompt("  Run OAuth authorization now? [Y/n]: ");
+            if (doAuth.toLowerCase() !== "n") {
+                const clientId = pluginConfig?.clientId ?? process.env.LINEAR_CLIENT_ID;
+                const clientSecret = pluginConfig?.clientSecret ?? process.env.LINEAR_CLIENT_SECRET;
+                if (!clientId || !clientSecret) {
+                    console.log("\n  ✗ OAuth client ID and secret not configured.");
+                    console.log("    Set LINEAR_CLIENT_ID and LINEAR_CLIENT_SECRET env vars,");
+                    console.log("    or add clientId/clientSecret to the plugin config in openclaw.json.");
+                    console.log("    Then re-run: openclaw openclaw-linear setup\n");
+                }
+                else {
+                    const gatewayPort = process.env.OPENCLAW_GATEWAY_PORT ?? "18789";
+                    const redirectUri = pluginConfig?.redirectUri
+                        ?? process.env.LINEAR_REDIRECT_URI
+                        ?? `http://localhost:${gatewayPort}/linear/oauth/callback`;
+                    const state = Math.random().toString(36).substring(7);
+                    const authUrl = `${LINEAR_OAUTH_AUTH_URL}?client_id=${clientId}&redirect_uri=${encodeURIComponent(redirectUri)}&response_type=code&scope=${encodeURIComponent(LINEAR_AGENT_SCOPES)}&state=${state}&actor=app`;
+                    console.log("\n  Opening Linear OAuth page...\n");
+                    console.log(`    ${authUrl}\n`);
+                    openBrowser(authUrl);
+                    const code = await prompt("  Paste the authorization code from Linear: ");
+                    if (code) {
+                        try {
+                            const response = await fetch(LINEAR_OAUTH_TOKEN_URL, {
+                                method: "POST",
+                                headers: { "Content-Type": "application/x-www-form-urlencoded" },
+                                body: new URLSearchParams({
+                                    grant_type: "authorization_code",
+                                    code,
+                                    client_id: clientId,
+                                    client_secret: clientSecret,
+                                    redirect_uri: redirectUri,
+                                }),
+                            });
+                            if (response.ok) {
+                                const tokens = await response.json();
+                                let store = { version: 1, profiles: {} };
+                                try {
+                                    const raw = readFileSync(AUTH_PROFILES_PATH, "utf8");
+                                    store = JSON.parse(raw);
+                                }
+                                catch { /* fresh store */ }
+                                store.profiles = store.profiles ?? {};
+                                store.profiles["linear:default"] = {
+                                    type: "oauth",
+                                    provider: "linear",
+                                    accessToken: tokens.access_token,
+                                    access: tokens.access_token,
+                                    refreshToken: tokens.refresh_token ?? null,
+                                    refresh: tokens.refresh_token ?? null,
+                                    expiresAt: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
+                                    expires: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : null,
+                                    scope: tokens.scope,
+                                };
+                                writeFileSync(AUTH_PROFILES_PATH, JSON.stringify(store, null, 2), "utf8");
+                                console.log("  ✓ Token saved to auth-profiles.json");
+                            }
+                            else {
+                                const error = await response.text();
+                                console.log(`  ✗ Token exchange failed (${response.status}): ${error}`);
+                            }
+                        }
+                        catch (err) {
+                            console.log(`  ✗ Token exchange error: ${err instanceof Error ? err.message : String(err)}`);
+                        }
+                    }
+                    else {
+                        console.log("  Skipped. Run: openclaw openclaw-linear auth later.");
+                    }
+                }
+            }
+            else {
+                console.log("  Skipped. Run: openclaw openclaw-linear auth when ready.");
+            }
+        }
+        // ---------------------------------------------------------------
+        // Step 3: Webhook
+        // ---------------------------------------------------------------
+        console.log("\nStep 3: Webhook");
+        console.log("─".repeat(50));
+        const freshToken = resolveLinearToken(pluginConfig);
+        if (!freshToken.accessToken) {
+            console.log("  ⚠ Skipped — no auth token available. Complete Step 2 first.");
+        }
+        else {
+            const { provisionWebhook, getWebhookStatus } = await import("./webhook-provision.js");
+            const linearApi = new LinearAgentApi(freshToken.accessToken, {
+                refreshToken: freshToken.refreshToken,
+                expiresAt: freshToken.expiresAt,
+            });
+            const webhookUrl = pluginConfig?.webhookUrl
+                ?? "https://linear.calltelemetry.com/linear/webhook";
+            try {
+                const status = await getWebhookStatus(linearApi, webhookUrl);
+                if (status && status.issues.length === 0) {
+                    console.log(`  ✓ Webhook already configured (${webhookUrl})`);
+                }
+                else {
+                    const result = await provisionWebhook(linearApi, webhookUrl, { allPublicTeams: true });
+                    if (result.action === "created") {
+                        console.log(`  ✓ Webhook created (${result.webhookId})`);
+                    }
+                    else if (result.action === "updated") {
+                        console.log(`  ✓ Webhook updated (${result.webhookId})`);
+                    }
+                    else {
+                        console.log(`  ✓ Webhook OK (${result.webhookId})`);
+                    }
+                }
+            }
+            catch (err) {
+                console.log(`  ⚠ Webhook check failed: ${err instanceof Error ? err.message : String(err)}`);
+                console.log("    Run: openclaw openclaw-linear webhooks setup");
+            }
+        }
+        // ---------------------------------------------------------------
+        // Step 4: Verify
+        // ---------------------------------------------------------------
+        console.log("\nStep 4: Verification");
+        console.log("─".repeat(50));
+        try {
+            const { runDoctor, formatReport } = await import("./doctor.js");
+            const report = await runDoctor({
+                fix: false,
+                json: false,
+                pluginConfig,
+            });
+            console.log(formatReport(report));
+            if (report.summary.errors === 0) {
+                const profiles = loadAgentProfiles();
+                const defaultAgent = Object.entries(profiles).find(([, p]) => p.isDefault);
+                const agentName = defaultAgent?.[1]?.label ?? defaultAgent?.[0] ?? "your agent";
+                console.log("─".repeat(50));
+                console.log(`Setup complete! ${agentName} is ready to receive Linear issues.`);
+                console.log(`\nRestart the gateway to apply changes:`);
+                console.log(`  systemctl --user restart openclaw-gateway\n`);
+            }
+            else {
+                console.log("─".repeat(50));
+                console.log("Some issues remain. Fix them and run: openclaw openclaw-linear doctor --fix\n");
+                process.exitCode = 1;
+            }
+        }
+        catch (err) {
+            console.log(`  ⚠ Doctor failed: ${err instanceof Error ? err.message : String(err)}`);
+            console.log("  Run: openclaw openclaw-linear doctor for details.\n");
+        }
+    });
+    // --- openclaw openclaw-linear worktrees ---
+    linear
+        .command("worktrees")
+        .description("List Codex worktrees (use --prune to remove specific ones)")
+        .option("--prune <path>", "Remove a specific worktree by path")
+        .action(async (opts) => {
+        if (opts.prune) {
+            try {
+                const { removeWorktree } = await import("./codex-worktree.js");
+                removeWorktree(opts.prune, { deleteBranch: true });
+                console.log(`\nRemoved: ${opts.prune}\n`);
+            }
+            catch (err) {
+                console.error(`\nFailed to remove ${opts.prune}: ${err}\n`);
+                process.exitCode = 1;
+            }
+            return;
+        }
+        const worktrees = listWorktrees();
+        if (worktrees.length === 0) {
+            console.log("\nNo Codex worktrees found.\n");
+            return;
+        }
+        console.log(`\nCodex Worktrees (${worktrees.length})`);
+        console.log("─".repeat(60));
+        for (const wt of worktrees) {
+            const ageH = Math.round(wt.ageMs / 3_600_000 * 10) / 10;
+            const changes = wt.hasChanges ? " (uncommitted changes)" : "";
+            console.log(`  ${wt.path}`);
+            console.log(`    branch: ${wt.branch}  age: ${ageH}h${changes}`);
+        }
+        console.log(`\nTo remove one: openclaw openclaw-linear worktrees --prune <path>\n`);
+    });
+    // --- openclaw openclaw-linear repos ---
+    const repos = linear
+        .command("repos")
+        .description("Validate multi-repo config and sync labels to Linear");
+    repos
+        .command("check")
+        .description("Validate repo paths and show what labels would be created (dry run)")
+        .action(async () => {
+        await reposAction(api, { dryRun: true });
+    });
+    repos
+        .command("sync")
+        .description("Create missing repo: labels in Linear from your repos config")
+        .action(async () => {
+        await reposAction(api, { dryRun: false });
+    });
+    // --- openclaw openclaw-linear prompts ---
+    const prompts = linear
+        .command("prompts")
+        .description("Manage pipeline prompt templates (prompts.yaml)");
+    prompts
+        .command("show")
+        .description("Print resolved prompts (global or per-project)")
+        .option("--worktree <path>", "Show merged prompts for a specific worktree")
+        .action(async (opts) => {
+        const pluginConfig = api.pluginConfig;
+        clearPromptCache();
+        const loaded = loadPrompts(pluginConfig, opts.worktree);
+        if (opts.worktree) {
+            console.log(`\nResolved prompts for worktree: ${opts.worktree}\n`);
+        }
+        else {
+            console.log(`\nGlobal resolved prompts\n`);
+        }
+        console.log(JSON.stringify(loaded, null, 2));
+        console.log();
+    });
+    prompts
+        .command("path")
+        .description("Print the resolved prompts.yaml file path")
+        .action(async () => {
+        const pluginConfig = api.pluginConfig;
+        const customPath = pluginConfig?.promptsPath;
+        let resolvedPath;
+        if (customPath) {
+            resolvedPath = customPath.startsWith("~")
+                ? customPath.replace("~", process.env.HOME ?? "")
+                : customPath;
+        }
+        else {
+            const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+            resolvedPath = join(pluginRoot, "prompts.yaml");
+        }
+        const exists = existsSync(resolvedPath);
+        console.log(`${resolvedPath} ${exists ? "(exists)" : "(not found — using defaults)"}`);
+    });
+    prompts
+        .command("validate")
+        .description("Validate prompts.yaml structure (global or per-project)")
+        .option("--worktree <path>", "Validate merged prompts for a specific worktree")
+        .action(async (opts) => {
+        const pluginConfig = api.pluginConfig;
+        clearPromptCache();
+        try {
+            const loaded = loadPrompts(pluginConfig, opts.worktree);
+            const errors = [];
+            if (!loaded.worker?.system)
+                errors.push("Missing worker.system");
+            if (!loaded.worker?.task)
+                errors.push("Missing worker.task");
+            if (!loaded.audit?.system)
+                errors.push("Missing audit.system");
+            if (!loaded.audit?.task)
+                errors.push("Missing audit.task");
+            if (!loaded.rework?.addendum)
+                errors.push("Missing rework.addendum");
+            // Check for template variables
+            const requiredVars = ["{{identifier}}", "{{title}}", "{{description}}", "{{worktreePath}}"];
+            for (const v of requiredVars) {
+                if (!loaded.worker.task.includes(v)) {
+                    errors.push(`worker.task missing template variable: ${v}`);
+                }
+                if (!loaded.audit.task.includes(v)) {
+                    errors.push(`audit.task missing template variable: ${v}`);
+                }
+            }
+            const label = opts.worktree ? `worktree ${opts.worktree}` : "global";
+            if (errors.length > 0) {
+                console.log(`\nValidation FAILED (${label}):\n`);
+                for (const e of errors)
+                    console.log(`  - ${e}`);
+                console.log();
+                process.exitCode = 1;
+            }
+            else {
+                console.log(`\nValidation PASSED (${label}) — all sections and template variables present.\n`);
+            }
+        }
+        catch (err) {
+            console.error(`\nFailed to load prompts: ${err}\n`);
+            process.exitCode = 1;
+        }
+    });
+    prompts
+        .command("init")
+        .description("Scaffold per-project .claw/prompts.yaml in a worktree")
+        .argument("<worktree-path>", "Path to the worktree")
+        .action(async (worktreePath) => {
+        const { mkdirSync, writeFileSync: writeFS } = await import("node:fs");
+        const clawDir = join(worktreePath, ".claw");
+        const promptsFile = join(clawDir, "prompts.yaml");
+        if (existsSync(promptsFile)) {
+            console.log(`\n  ${promptsFile} already exists.\n`);
+            return;
+        }
+        mkdirSync(clawDir, { recursive: true });
+        writeFS(promptsFile, [
+            "# Per-project prompt overrides for Linear Agent pipeline.",
+            "# Only include sections/fields you want to override.",
+            "# Unspecified fields inherit from the global prompts.yaml.",
+            "#",
+            "# Available sections: worker, audit, rework",
+            "# Template variables: {{identifier}}, {{title}}, {{description}}, {{worktreePath}}, {{tier}}, {{attempt}}, {{gaps}}",
+            "",
+            "# worker:",
+            "#   system: \"Custom system prompt for workers in this project.\"",
+            "#   task: \"Implement issue {{identifier}}: {{title}}\\n\\n{{description}}\\n\\nWorktree: {{worktreePath}}\"",
+            "",
+            "# audit:",
+            "#   system: \"Custom audit system prompt for this project.\"",
+            "",
+            "# rework:",
+            "#   addendum: \"Custom rework addendum for this project.\"",
+            "",
+        ].join("\n"), "utf-8");
+        console.log(`\n  Created: ${promptsFile}`);
+        console.log(`  Edit this file to customize prompts for this worktree.\n`);
+    });
+    prompts
+        .command("diff")
+        .description("Show differences between global and per-project prompts")
+        .argument("<worktree-path>", "Path to the worktree")
+        .action(async (worktreePath) => {
+        const pluginConfig = api.pluginConfig;
+        clearPromptCache();
+        const global = loadPrompts(pluginConfig);
+        const merged = loadPrompts(pluginConfig, worktreePath);
+        const projectFile = join(worktreePath, ".claw", "prompts.yaml");
+        if (!existsSync(projectFile)) {
+            console.log(`\n  No per-project prompts at ${projectFile}`);
+            console.log(`  Run 'openclaw openclaw-linear prompts init ${worktreePath}' to create one.\n`);
+            return;
+        }
+        console.log(`\nPrompt diff: global vs ${worktreePath}\n`);
+        let hasDiffs = false;
+        for (const section of ["worker", "audit", "rework"]) {
+            const globalSection = global[section];
+            const mergedSection = merged[section];
+            for (const [key, val] of Object.entries(mergedSection)) {
+                if (globalSection[key] !== val) {
+                    hasDiffs = true;
+                    console.log(`  ${section}.${key}:`);
+                    console.log(`    global:  ${globalSection[key]?.slice(0, 100)}...`);
+                    console.log(`    project: ${val.slice(0, 100)}...`);
+                    console.log();
+                }
+            }
+        }
+        if (!hasDiffs) {
+            console.log("  No differences — per-project prompts match global.\n");
+        }
+    });
+    // --- openclaw openclaw-linear notify ---
+    const notifyCmd = linear
+        .command("notify")
+        .description("Manage dispatch lifecycle notifications");
+    notifyCmd
+        .command("status")
+        .description("Show current notification target configuration")
+        .action(async () => {
+        const pluginConfig = api.pluginConfig;
+        const config = parseNotificationsConfig(pluginConfig);
+        console.log("\nNotification Targets");
+        console.log("─".repeat(50));
+        if (!config.targets?.length) {
+            console.log("\n  No notification targets configured.");
+            console.log("  Run 'openclaw openclaw-linear notify setup' to configure.\n");
+            return;
+        }
+        for (const t of config.targets) {
+            const acct = t.accountId ? ` (account: ${t.accountId})` : "";
+            console.log(`  ${t.channel}:  ${t.target}${acct}`);
+        }
+        // Show event toggles if any are suppressed
+        const suppressed = Object.entries(config.events ?? {})
+            .filter(([, v]) => v === false)
+            .map(([k]) => k);
+        if (suppressed.length > 0) {
+            console.log(`\n  Suppressed events: ${suppressed.join(", ")}`);
+        }
+        console.log();
+    });
+    notifyCmd
+        .command("test")
+        .description("Send a test notification to all configured targets")
+        .option("--channel <name>", "Test only targets for a specific channel (discord, slack, telegram, etc.)")
+        .action(async (opts) => {
+        const pluginConfig = api.pluginConfig;
+        const config = parseNotificationsConfig(pluginConfig);
+        const testPayload = {
+            identifier: "TEST-0",
+            title: "Test notification from Linear plugin",
+            status: "test",
+        };
+        const testKind = "dispatch";
+        const message = formatMessage(testKind, testPayload);
+        console.log("\nSending test notification...\n");
+        if (!config.targets?.length) {
+            console.error("  No notification targets configured. Run 'openclaw openclaw-linear notify setup' first.\n");
+            process.exitCode = 1;
+            return;
+        }
+        const targets = opts.channel
+            ? config.targets.filter((t) => t.channel === opts.channel)
+            : config.targets;
+        if (targets.length === 0) {
+            console.error(`  No targets found for channel "${opts.channel}".\n`);
+            process.exitCode = 1;
+            return;
+        }
+        for (const target of targets) {
+            try {
+                await sendToTarget(target, message, api.runtime);
+                console.log(`  ${target.channel}:  SENT to ${target.target}`);
+                console.log(`            "${message}"`);
+            }
+            catch (err) {
+                console.error(`  ${target.channel}:  FAILED — ${err instanceof Error ? err.message : String(err)}`);
+            }
+        }
+        console.log();
+    });
+    notifyCmd
+        .command("setup")
+        .description("Interactive setup for notification targets")
+        .action(async () => {
+        const pluginConfig = api.pluginConfig;
+        const config = parseNotificationsConfig(pluginConfig);
+        console.log("\nNotification Target Setup");
+        console.log("─".repeat(50));
+        console.log("  Dispatch lifecycle notifications can be sent to any OpenClaw channel.");
+        console.log("  Add multiple targets for fan-out delivery.\n");
+        // Show current targets
+        if (config.targets?.length) {
+            console.log("  Current targets:");
+            for (const t of config.targets) {
+                const acct = t.accountId ? ` (account: ${t.accountId})` : "";
+                console.log(`    ${t.channel}: ${t.target}${acct}`);
+            }
+            console.log();
+        }
+        const newTargets = [...(config.targets ?? [])];
+        const supportedChannels = ["discord", "slack", "telegram", "signal"];
+        // Add targets loop
+        let addMore = true;
+        while (addMore) {
+            const channelAnswer = await prompt(`Add notification target? (${supportedChannels.join("/")}) or blank to finish: `);
+            if (!channelAnswer) {
+                addMore = false;
+                break;
+            }
+            const channel = channelAnswer.toLowerCase().trim();
+            const targetId = await prompt(`  ${channel} target ID (channel/group/user): `);
+            if (!targetId)
+                continue;
+            let accountId;
+            if (channel === "slack") {
+                const acct = await prompt("  Slack account ID (leave blank for default): ");
+                accountId = acct || undefined;
+            }
+            newTargets.push({ channel, target: targetId, ...(accountId ? { accountId } : {}) });
+            console.log(`  Added: ${channel} → ${targetId}\n`);
+        }
+        // Summary
+        console.log("\nConfiguration Summary");
+        console.log("─".repeat(50));
+        if (newTargets.length === 0) {
+            console.log("  No targets configured (notifications disabled).");
+        }
+        else {
+            for (const t of newTargets) {
+                const acct = t.accountId ? ` (account: ${t.accountId})` : "";
+                console.log(`  ${t.channel}: ${t.target}${acct}`);
+            }
+        }
+        if (JSON.stringify(newTargets) === JSON.stringify(config.targets ?? [])) {
+            console.log("\n  No changes made.\n");
+            return;
+        }
+        // Write config
+        const confirmAnswer = await prompt("\nApply these changes? [Y/n]: ");
+        if (confirmAnswer.toLowerCase() === "n") {
+            console.log("  Aborted.\n");
+            return;
+        }
+        try {
+            const runtimeConfig = api.runtime.config.loadConfig();
+            const pluginEntries = runtimeConfig.plugins?.entries ?? {};
+            const linearConfig = pluginEntries["openclaw-linear"]?.config ?? {};
+            linearConfig.notifications = {
+                ...linearConfig.notifications,
+                targets: newTargets,
+            };
+            pluginEntries["openclaw-linear"] = {
+                ...pluginEntries["openclaw-linear"],
+                config: linearConfig,
+            };
+            runtimeConfig.plugins = { ...runtimeConfig.plugins, entries: pluginEntries };
+            api.runtime.config.writeConfigFile(runtimeConfig);
+            console.log("\n  Configuration saved. Restart gateway to apply: systemctl --user restart openclaw-gateway\n");
+        }
+        catch (err) {
+            console.error(`\n  Failed to save config: ${err instanceof Error ? err.message : String(err)}`);
+            console.error("  You can manually add these values to openclaw.json → plugins.entries.openclaw-linear.config\n");
+            process.exitCode = 1;
+        }
+    });
+    // --- openclaw openclaw-linear doctor ---
+    linear
+        .command("doctor")
+        .description("Run comprehensive health checks on the Linear plugin")
+        .option("--fix", "Auto-fix safe issues (chmod, stale locks, prune old dispatches)")
+        .option("--json", "Output results as JSON")
+        .action(async (opts) => {
+        const { runDoctor, formatReport, formatReportJson } = await import("./doctor.js");
+        const pluginConfig = api.pluginConfig;
+        const report = await runDoctor({
+            fix: opts.fix ?? false,
+            json: opts.json ?? false,
+            pluginConfig,
+        });
+        if (opts.json) {
+            console.log(formatReportJson(report));
+        }
+        else {
+            console.log(formatReport(report));
+        }
+        if (report.summary.errors > 0) {
+            process.exitCode = 1;
+        }
+    });
+    // --- openclaw openclaw-linear code-run ---
+    const codeRunCmd = linear
+        .command("code-run")
+        .description("Manage and diagnose coding tool backends");
+    codeRunCmd
+        .command("doctor")
+        .description("Deep health check: verify each coding backend (Claude, Codex, Gemini) is callable")
+        .option("--json", "Output results as JSON")
+        .action(async (opts) => {
+        const { checkCodeRunDeep, buildSummary, formatReport, formatReportJson } = await import("./doctor.js");
+        const pluginConfig = api.pluginConfig;
+        const sections = await checkCodeRunDeep(pluginConfig);
+        const report = { sections, summary: buildSummary(sections) };
+        if (opts.json) {
+            console.log(formatReportJson(report));
+        }
+        else {
+            console.log(formatReport(report));
+        }
+        if (report.summary.errors > 0) {
+            process.exitCode = 1;
+        }
+    });
+    // --- openclaw openclaw-linear webhooks ---
+    const webhooksCmd = linear
+        .command("webhooks")
+        .description("Manage Linear webhook subscriptions");
+    webhooksCmd
+        .command("status")
+        .description("Show current webhook configuration in Linear")
+        .action(async () => {
+        const pluginConfig = api.pluginConfig;
+        const tokenInfo = resolveLinearToken(pluginConfig);
+        if (!tokenInfo.accessToken) {
+            console.error("\n  No Linear token found. Run \"openclaw openclaw-linear auth\" first.\n");
+            process.exitCode = 1;
+            return;
+        }
+        const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+            refreshToken: tokenInfo.refreshToken,
+            expiresAt: tokenInfo.expiresAt,
+        });
+        console.log("\nLinear Webhooks");
+        console.log("─".repeat(50));
+        const webhooks = await linearApi.listWebhooks();
+        if (webhooks.length === 0) {
+            console.log("\n  No webhooks found.");
+            console.log("  Run \"openclaw openclaw-linear webhooks setup\" to create one.\n");
+            return;
+        }
+        for (const wh of webhooks) {
+            const status = wh.enabled ? "enabled" : "DISABLED";
+            const label = wh.label ?? "(no label)";
+            const team = wh.team ? ` (team: ${wh.team.name})` : " (all teams)";
+            console.log(`\n  ${label}${team}`);
+            console.log(`    ID:      ${wh.id}`);
+            console.log(`    URL:     ${wh.url}`);
+            console.log(`    Status:  ${status}`);
+            console.log(`    Events:  ${wh.resourceTypes.join(", ")}`);
+            console.log(`    Created: ${wh.createdAt}`);
+        }
+        console.log();
+    });
+    webhooksCmd
+        .command("setup")
+        .description("Auto-provision or fix the workspace webhook (create/update as needed)")
+        .option("--url <url>", "Webhook URL (default: from Cloudflare tunnel config)")
+        .option("--team <id>", "Restrict to a specific team ID (default: all public teams)")
+        .option("--dry-run", "Show what would change without making changes")
+        .action(async (opts) => {
+        const pluginConfig = api.pluginConfig;
+        const { provisionWebhook, getWebhookStatus, REQUIRED_RESOURCE_TYPES } = await import("./webhook-provision.js");
+        const tokenInfo = resolveLinearToken(pluginConfig);
+        if (!tokenInfo.accessToken) {
+            console.error("\n  No Linear token found. Run \"openclaw openclaw-linear auth\" first.\n");
+            process.exitCode = 1;
+            return;
+        }
+        const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+            refreshToken: tokenInfo.refreshToken,
+            expiresAt: tokenInfo.expiresAt,
+        });
+        const webhookUrl = opts.url
+            ?? pluginConfig?.webhookUrl
+            ?? "https://linear.calltelemetry.com/linear/webhook";
+        console.log("\nWebhook Provisioning");
+        console.log("─".repeat(50));
+        console.log(`  URL:    ${webhookUrl}`);
+        console.log(`  Events: ${[...REQUIRED_RESOURCE_TYPES].join(", ")}`);
+        if (opts.dryRun) {
+            const status = await getWebhookStatus(linearApi, webhookUrl);
+            if (!status) {
+                console.log("\n  Would CREATE a new webhook with the above config.");
+            }
+            else if (status.issues.length === 0) {
+                console.log("\n  Webhook already configured correctly. No changes needed.");
+            }
+            else {
+                console.log("\n  Would UPDATE existing webhook:");
+                for (const issue of status.issues) {
+                    console.log(`    - Fix: ${issue}`);
+                }
+            }
+            console.log();
+            return;
+        }
+        const result = await provisionWebhook(linearApi, webhookUrl, {
+            teamId: opts.team,
+            allPublicTeams: !opts.team,
+        });
+        switch (result.action) {
+            case "created":
+                console.log(`\n  Created webhook: ${result.webhookId}`);
+                break;
+            case "updated":
+                console.log(`\n  Updated webhook: ${result.webhookId}`);
+                for (const change of result.changes ?? []) {
+                    console.log(`    - ${change}`);
+                }
+                break;
+            case "already_ok":
+                console.log(`\n  Webhook already configured correctly (${result.webhookId}). No changes needed.`);
+                break;
+        }
+        console.log();
+    });
+    webhooksCmd
+        .command("delete")
+        .description("Delete a webhook by ID")
+        .argument("<webhook-id>", "ID of the webhook to delete")
+        .action(async (webhookId) => {
+        const pluginConfig = api.pluginConfig;
+        const tokenInfo = resolveLinearToken(pluginConfig);
+        if (!tokenInfo.accessToken) {
+            console.error("\n  No Linear token found.\n");
+            process.exitCode = 1;
+            return;
+        }
+        const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+            refreshToken: tokenInfo.refreshToken,
+            expiresAt: tokenInfo.expiresAt,
+        });
+        const confirmAnswer = await prompt(`Delete webhook ${webhookId}? [y/N]: `);
+        if (confirmAnswer.toLowerCase() !== "y") {
+            console.log("  Aborted.\n");
+            return;
+        }
+        const success = await linearApi.deleteWebhook(webhookId);
+        if (success) {
+            console.log(`\n  Deleted webhook ${webhookId}\n`);
+        }
+        else {
+            console.error(`\n  Failed to delete webhook ${webhookId}\n`);
+            process.exitCode = 1;
+        }
+    });
+}
+// ---------------------------------------------------------------------------
+// repos sync / check helper
+// ---------------------------------------------------------------------------
+const REPO_LABEL_COLOR = "#5e6ad2"; // Linear indigo
+async function reposAction(api, opts) {
+    const pluginConfig = api.pluginConfig;
+    const reposMap = pluginConfig?.repos ?? {};
+    const repoNames = Object.keys(reposMap);
+    const mode = opts.dryRun ? "Repos Check" : "Repos Sync";
+    console.log(`\n${mode}`);
+    console.log("─".repeat(40));
+    // 1. Validate config
+    if (repoNames.length === 0) {
+        console.log(`\n  No "repos" configured in plugin config.`);
+        console.log(`  Add a repos map to openclaw.json → plugins.entries.openclaw-linear.config:`);
+        console.log(`\n    "repos": {`);
+        console.log(`      "api": "~/repos/api",`);
+        console.log(`      "frontend": "~/repos/frontend"`);
+        console.log(`    }\n`);
+        return;
+    }
+    // 2. Validate each repo path
+    console.log("\n  Repos from config:");
+    const warnings = [];
+    for (const name of repoNames) {
+        const repoPath = reposMap[name];
+        const status = validateRepoPath(repoPath);
+        const pad = name.padEnd(16);
+        if (!status.exists) {
+            console.log(`  \u2717 ${pad} ${repoPath} (path not found)`);
+            warnings.push(`"${name}" at ${repoPath} does not exist`);
+        }
+        else if (!status.isGitRepo) {
+            console.log(`  \u2717 ${pad} ${repoPath} (not a git repo)`);
+            warnings.push(`"${name}" at ${repoPath} is not a git repository`);
+        }
+        else if (status.isSubmodule) {
+            console.log(`  \u26a0 ${pad} ${repoPath} (submodule)`);
+            warnings.push(`"${name}" at ${repoPath} is a git submodule`);
+        }
+        else {
+            console.log(`  \u2714 ${pad} ${repoPath} (git repo)`);
+        }
+    }
+    // 3. Connect to Linear
+    const tokenInfo = resolveLinearToken(pluginConfig);
+    if (!tokenInfo.accessToken) {
+        console.log(`\n  No Linear token found. Run "openclaw openclaw-linear auth" first.\n`);
+        process.exitCode = 1;
+        return;
+    }
+    const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+        clientId: pluginConfig?.clientId,
+        clientSecret: pluginConfig?.clientSecret,
+    });
+    // 4. Get teams
+    let teams;
+    try {
+        teams = await linearApi.getTeams();
+    }
+    catch (err) {
+        console.log(`\n  Failed to fetch teams: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exitCode = 1;
+        return;
+    }
+    if (teams.length === 0) {
+        console.log(`\n  No teams found in your Linear workspace.\n`);
+        return;
+    }
+    // 5. Sync labels per team
+    let totalCreated = 0;
+    let totalExisted = 0;
+    for (const team of teams) {
+        console.log(`\n  Team: ${team.name} (${team.key})`);
+        let existingLabels;
+        try {
+            existingLabels = await linearApi.getTeamLabels(team.id);
+        }
+        catch (err) {
+            console.log(`    Failed to fetch labels: ${err instanceof Error ? err.message : String(err)}`);
+            continue;
+        }
+        const existingNames = new Set(existingLabels.map(l => l.name.toLowerCase()));
+        for (const name of repoNames) {
+            const labelName = `repo:${name}`;
+            if (existingNames.has(labelName.toLowerCase())) {
+                console.log(`  \u2714 ${labelName.padEnd(24)} already exists`);
+                totalExisted++;
+            }
+            else if (opts.dryRun) {
+                console.log(`  + ${labelName.padEnd(24)} would be created`);
+            }
+            else {
+                try {
+                    await linearApi.createLabel(team.id, labelName, {
+                        color: REPO_LABEL_COLOR,
+                        description: `Multi-repo dispatch: ${name}`,
+                    });
+                    console.log(`  + ${labelName.padEnd(24)} created`);
+                    totalCreated++;
+                }
+                catch (err) {
+                    console.log(`  \u2717 ${labelName.padEnd(24)} failed: ${err instanceof Error ? err.message : String(err)}`);
+                }
+            }
+        }
+    }
+    // 6. Summary
+    if (opts.dryRun) {
+        const wouldCreate = repoNames.length * teams.length - totalExisted;
+        console.log(`\n  Dry run: ${wouldCreate} label(s) would be created, ${totalExisted} already exist`);
+    }
+    else {
+        console.log(`\n  Summary: ${totalCreated} created, ${totalExisted} already existed`);
+    }
+    // 7. Submodule warnings
+    const submoduleWarnings = warnings.filter(w => w.includes("submodule"));
+    if (submoduleWarnings.length > 0) {
+        console.log(`\n  \u26a0 Submodule warning:`);
+        for (const w of submoduleWarnings) {
+            console.log(`    ${w}`);
+        }
+        console.log(`    Multi-repo dispatch uses "git worktree add" which doesn't work on submodules.`);
+        console.log(`    Options:`);
+        console.log(`    1. Clone the repo as a standalone repo instead`);
+        console.log(`    2. Remove it from "repos" config and use the parent repo as codexBaseRepo`);
+    }
+    // Other warnings
+    const otherWarnings = warnings.filter(w => !w.includes("submodule"));
+    if (otherWarnings.length > 0) {
+        console.log(`\n  Warnings:`);
+        for (const w of otherWarnings) {
+            console.log(`    \u26a0 ${w}`);
+        }
+    }
+    console.log();
+}

--- a/dist/src/infra/codex-worktree.js
+++ b/dist/src/infra/codex-worktree.js
@@ -1,0 +1,361 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, statSync, readdirSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+import { ensureGitignore } from "../pipeline/artifacts.js";
+const DEFAULT_BASE_REPO = path.join(homedir(), "ai-workspace");
+const DEFAULT_WORKTREE_BASE_DIR = path.join(homedir(), ".openclaw", "worktrees");
+function resolveBaseDir(baseDir) {
+    if (!baseDir)
+        return DEFAULT_WORKTREE_BASE_DIR;
+    if (baseDir.startsWith("~/"))
+        return baseDir.replace("~", homedir());
+    return baseDir;
+}
+function git(args, cwd) {
+    return execFileSync("git", args, {
+        cwd,
+        encoding: "utf8",
+        timeout: 30_000,
+    }).trim();
+}
+function gitLong(args, cwd, timeout = 120_000) {
+    return execFileSync("git", args, {
+        cwd,
+        encoding: "utf8",
+        timeout,
+    }).trim();
+}
+/**
+ * Create a git worktree for isolated work on a Linear issue.
+ *
+ * Path: {baseDir}/{issueIdentifier}/ — deterministic, persistent.
+ * Branch: codex/{issueIdentifier}
+ *
+ * Idempotent: if the worktree already exists, returns it without recreating.
+ * If the branch exists but the worktree is gone, recreates the worktree from
+ * the existing branch (resume scenario).
+ */
+export function createWorktree(issueIdentifier, opts) {
+    const repo = opts?.baseRepo ?? DEFAULT_BASE_REPO;
+    const baseDir = resolveBaseDir(opts?.baseDir);
+    if (!existsSync(repo)) {
+        throw new Error(`Base repo not found: ${repo}`);
+    }
+    // Ensure base directory exists
+    if (!existsSync(baseDir)) {
+        mkdirSync(baseDir, { recursive: true });
+    }
+    const branch = `codex/${issueIdentifier}`;
+    const worktreePath = path.join(baseDir, issueIdentifier);
+    // Fetch latest from origin (best effort) — do this early so both
+    // resume and fresh paths have up-to-date refs.
+    try {
+        git(["fetch", "origin"], repo);
+    }
+    catch {
+        // Offline or no remote — continue with local state
+    }
+    // Idempotent: if worktree already exists, return it
+    if (existsSync(worktreePath)) {
+        try {
+            // Verify it's a valid git worktree
+            git(["rev-parse", "--git-dir"], worktreePath);
+            ensureGitignore(worktreePath);
+            return { path: worktreePath, branch, resumed: true };
+        }
+        catch {
+            // Directory exists but isn't a valid worktree — remove and recreate
+            try {
+                git(["worktree", "remove", "--force", worktreePath], repo);
+            }
+            catch { /* best effort */ }
+        }
+    }
+    // Check if branch already exists (resume scenario)
+    const branchExists = branchExistsInRepo(branch, repo);
+    if (branchExists) {
+        // Recreate worktree from existing branch — preserves previous work
+        git(["worktree", "add", worktreePath, branch], repo);
+        ensureGitignore(worktreePath);
+        return { path: worktreePath, branch, resumed: true };
+    }
+    // Fresh start: new branch off HEAD
+    git(["worktree", "add", "-b", branch, worktreePath], repo);
+    ensureGitignore(worktreePath);
+    return { path: worktreePath, branch, resumed: false };
+}
+/**
+ * Create worktrees for multiple repos.
+ *
+ * Layout: {baseDir}/{issueIdentifier}/{repoName}/
+ * Branch: codex/{issueIdentifier} (same branch name in each repo)
+ *
+ * Each individual repo worktree follows the same idempotent/resume logic
+ * as createWorktree: if the worktree or branch already exists, it resumes.
+ */
+export function createMultiWorktree(identifier, repos, opts) {
+    const baseDir = resolveBaseDir(opts?.baseDir);
+    const parentPath = path.join(baseDir, identifier);
+    // Ensure parent directory exists
+    if (!existsSync(parentPath)) {
+        mkdirSync(parentPath, { recursive: true });
+    }
+    const branch = `codex/${identifier}`;
+    const worktrees = [];
+    for (const repo of repos) {
+        if (!existsSync(repo.path)) {
+            throw new Error(`Repo not found: ${repo.name} at ${repo.path}`);
+        }
+        const worktreePath = path.join(parentPath, repo.name);
+        // Fetch latest from origin (best effort)
+        try {
+            git(["fetch", "origin"], repo.path);
+        }
+        catch {
+            // Offline or no remote — continue with local state
+        }
+        // Idempotent: if worktree already exists, resume it
+        if (existsSync(worktreePath)) {
+            try {
+                git(["rev-parse", "--git-dir"], worktreePath);
+                ensureGitignore(worktreePath);
+                worktrees.push({ repoName: repo.name, path: worktreePath, branch, resumed: true });
+                continue;
+            }
+            catch {
+                // Directory exists but isn't a valid worktree — remove and recreate
+                try {
+                    git(["worktree", "remove", "--force", worktreePath], repo.path);
+                }
+                catch { /* best effort */ }
+            }
+        }
+        // Check if branch already exists (resume scenario)
+        const exists = branchExistsInRepo(branch, repo.path);
+        if (exists) {
+            git(["worktree", "add", worktreePath, branch], repo.path);
+            ensureGitignore(worktreePath);
+            worktrees.push({ repoName: repo.name, path: worktreePath, branch, resumed: true });
+        }
+        else {
+            git(["worktree", "add", "-b", branch, worktreePath], repo.path);
+            ensureGitignore(worktreePath);
+            worktrees.push({ repoName: repo.name, path: worktreePath, branch, resumed: false });
+        }
+    }
+    return { parentPath, worktrees };
+}
+/**
+ * Check if a branch exists in the repo.
+ */
+function branchExistsInRepo(branch, repo) {
+    try {
+        const result = git(["branch", "--list", branch], repo);
+        return result.trim().length > 0;
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Get the status of a worktree: changed files, uncommitted work, last commit.
+ */
+export function getWorktreeStatus(worktreePath) {
+    if (!existsSync(worktreePath)) {
+        return { filesChanged: [], hasUncommitted: false, lastCommit: null };
+    }
+    const diffOutput = git(["diff", "--name-only", "HEAD"], worktreePath);
+    const stagedOutput = git(["diff", "--name-only", "--cached"], worktreePath);
+    const untrackedOutput = git(["ls-files", "--others", "--exclude-standard"], worktreePath);
+    const allFiles = new Set();
+    for (const line of [...diffOutput.split("\n"), ...stagedOutput.split("\n"), ...untrackedOutput.split("\n")]) {
+        const trimmed = line.trim();
+        if (trimmed)
+            allFiles.add(trimmed);
+    }
+    const hasUncommitted = allFiles.size > 0;
+    let lastCommit = null;
+    try {
+        lastCommit = git(["log", "-1", "--oneline"], worktreePath);
+    }
+    catch {
+        // No commits yet
+    }
+    return {
+        filesChanged: [...allFiles],
+        hasUncommitted,
+        lastCommit,
+    };
+}
+/**
+ * Remove a worktree and optionally delete its branch.
+ */
+export function removeWorktree(worktreePath, opts) {
+    const repo = opts?.baseRepo ?? DEFAULT_BASE_REPO;
+    if (existsSync(worktreePath)) {
+        git(["worktree", "remove", "--force", worktreePath], repo);
+    }
+    if (opts?.deleteBranch) {
+        // Extract issue identifier from worktree path to find matching branch
+        const dirName = path.basename(worktreePath);
+        const branch = `codex/${dirName}`;
+        try {
+            git(["branch", "-D", branch], repo);
+        }
+        catch {
+            // Branch doesn't exist or already deleted
+        }
+    }
+}
+/**
+ * Push the worktree branch and create a GitHub PR via `gh`.
+ */
+export function createPullRequest(worktreePath, title, body) {
+    // Commit any uncommitted changes first
+    const status = getWorktreeStatus(worktreePath);
+    if (status.hasUncommitted) {
+        git(["add", "-A"], worktreePath);
+        git([
+            "-c", "user.name=claw",
+            "-c", "user.email=claw@calltelemetry.com",
+            "commit", "-m", title,
+        ], worktreePath);
+    }
+    // Get branch name
+    const branch = git(["rev-parse", "--abbrev-ref", "HEAD"], worktreePath);
+    // Push branch
+    git(["push", "-u", "origin", branch], worktreePath);
+    // Create PR via gh CLI
+    const prUrl = execFileSync("gh", ["pr", "create", "--title", title, "--body", body, "--head", branch], { cwd: worktreePath, encoding: "utf8", timeout: 30_000 }).trim();
+    return { prUrl };
+}
+/**
+ * List all worktrees in the configured base directory.
+ */
+export function listWorktrees(opts) {
+    const baseDir = resolveBaseDir(opts?.baseDir);
+    const entries = [];
+    if (!existsSync(baseDir))
+        return [];
+    let dirs;
+    try {
+        dirs = readdirSync(baseDir).map((d) => path.join(baseDir, d));
+    }
+    catch {
+        return [];
+    }
+    for (const dir of dirs) {
+        if (!existsSync(dir))
+            continue;
+        try {
+            const stat = statSync(dir);
+            if (!stat.isDirectory())
+                continue;
+            // Verify it's a git worktree
+            try {
+                git(["rev-parse", "--git-dir"], dir);
+            }
+            catch {
+                continue; // Not a git worktree
+            }
+            let branch = "unknown";
+            try {
+                branch = git(["rev-parse", "--abbrev-ref", "HEAD"], dir);
+            }
+            catch { }
+            let hasChanges = false;
+            try {
+                const status = getWorktreeStatus(dir);
+                hasChanges = status.hasUncommitted;
+            }
+            catch { }
+            entries.push({
+                path: dir,
+                branch,
+                issueIdentifier: path.basename(dir),
+                ageMs: Date.now() - stat.mtimeMs,
+                hasChanges,
+            });
+        }
+        catch {
+            // Skip unreadable dirs
+        }
+    }
+    return entries.sort((a, b) => b.ageMs - a.ageMs);
+}
+/**
+ * Prepare a worktree for a code run:
+ *   1. Pull latest from origin for the issue branch (fast-forward only)
+ *   2. Initialize and update all git submodules recursively
+ *
+ * Safe to call on every run — idempotent. Failures are non-fatal;
+ * the code run proceeds even if pull or submodule init fails.
+ */
+export function prepareWorkspace(worktreePath, branch) {
+    const errors = [];
+    let pulled = false;
+    let pullOutput;
+    let submodulesInitialized = false;
+    let submoduleOutput;
+    // 1. Pull latest from origin (ff-only to avoid merge conflicts)
+    try {
+        // Check if remote branch exists before pulling
+        const remoteBranch = `origin/${branch}`;
+        try {
+            git(["rev-parse", "--verify", remoteBranch], worktreePath);
+            // Remote branch exists — pull latest
+            pullOutput = git(["pull", "--ff-only", "origin", branch], worktreePath);
+            pulled = true;
+        }
+        catch {
+            // Remote branch doesn't exist yet (fresh issue branch) — nothing to pull
+            pullOutput = "remote branch not found, skipping pull";
+        }
+    }
+    catch (err) {
+        const msg = `pull failed: ${err}`;
+        errors.push(msg);
+        pullOutput = msg;
+    }
+    // 2. Initialize and update all submodules recursively
+    try {
+        submoduleOutput = gitLong(["submodule", "update", "--init", "--recursive"], worktreePath, 120_000);
+        submodulesInitialized = true;
+    }
+    catch (err) {
+        const msg = `submodule init failed: ${err}`;
+        errors.push(msg);
+        submoduleOutput = msg;
+    }
+    return { pulled, pullOutput, submodulesInitialized, submoduleOutput, errors };
+}
+/**
+ * Remove worktrees older than maxAgeMs.
+ * Returns list of removed paths.
+ */
+export function pruneStaleWorktrees(maxAgeMs = 24 * 60 * 60_000, opts) {
+    const worktrees = listWorktrees(opts);
+    const repo = opts?.baseRepo ?? DEFAULT_BASE_REPO;
+    const removed = [];
+    const skipped = [];
+    const errors = [];
+    for (const wt of worktrees) {
+        if (wt.ageMs < maxAgeMs) {
+            skipped.push(wt.path);
+            continue;
+        }
+        if (opts?.dryRun) {
+            removed.push(wt.path);
+            continue;
+        }
+        try {
+            removeWorktree(wt.path, { deleteBranch: true, baseRepo: repo });
+            removed.push(wt.path);
+        }
+        catch (err) {
+            errors.push(`${wt.path}: ${err}`);
+        }
+    }
+    return { removed, skipped, errors };
+}

--- a/dist/src/infra/commands.js
+++ b/dist/src/infra/commands.js
@@ -1,0 +1,115 @@
+import { readDispatchState, getActiveDispatch, listActiveDispatches, removeActiveDispatch, transitionDispatch, TransitionError, registerDispatch, } from "../pipeline/dispatch-state.js";
+export function registerDispatchCommands(api) {
+    const pluginConfig = api.pluginConfig;
+    const statePath = pluginConfig?.dispatchStatePath;
+    api.registerCommand({
+        name: "dispatch",
+        description: "Manage dispatches: list, status <id>, retry <id>, escalate <id>",
+        acceptsArgs: true,
+        handler: async (ctx) => {
+            const args = (ctx.args ?? "").trim().split(/\s+/);
+            const sub = args[0]?.toLowerCase();
+            const id = args[1];
+            if (!sub || sub === "list") {
+                return await handleList(statePath);
+            }
+            if (sub === "status" && id) {
+                return await handleStatus(id, statePath);
+            }
+            if (sub === "retry" && id) {
+                return await handleRetry(id, statePath, api);
+            }
+            if (sub === "escalate" && id) {
+                const reason = args.slice(2).join(" ") || "manual escalation";
+                return await handleEscalate(id, reason, statePath, api);
+            }
+            return {
+                text: [
+                    "**Dispatch Commands:**",
+                    "`/dispatch list` — show active dispatches",
+                    "`/dispatch status <id>` — phase/attempt details",
+                    "`/dispatch retry <id>` — reset stuck → dispatched",
+                    "`/dispatch escalate <id> [reason]` — force to stuck",
+                ].join("\n"),
+            };
+        },
+    });
+}
+async function handleList(statePath) {
+    const state = await readDispatchState(statePath);
+    const active = listActiveDispatches(state);
+    if (active.length === 0) {
+        return { text: "No active dispatches." };
+    }
+    const lines = active.map((d) => {
+        const age = Math.round((Date.now() - new Date(d.dispatchedAt).getTime()) / 60_000);
+        return `**${d.issueIdentifier}** — ${d.status} (${d.tier}, attempt ${d.attempt}, ${age}m)`;
+    });
+    return { text: `**Active Dispatches (${active.length})**\n${lines.join("\n")}` };
+}
+async function handleStatus(id, statePath) {
+    const state = await readDispatchState(statePath);
+    const d = getActiveDispatch(state, id);
+    if (!d) {
+        const completed = state.dispatches.completed[id];
+        if (completed) {
+            return {
+                text: `**${id}** — completed (${completed.status}, ${completed.tier}, ${completed.totalAttempts ?? 0} attempts)`,
+            };
+        }
+        return { text: `No dispatch found for ${id}.` };
+    }
+    const age = Math.round((Date.now() - new Date(d.dispatchedAt).getTime()) / 60_000);
+    const lines = [
+        `**${d.issueIdentifier}** — ${d.issueTitle ?? d.issueIdentifier}`,
+        `Status: ${d.status} | Tier: ${d.tier} | Attempt: ${d.attempt}`,
+        `Age: ${age}m | Worktree: \`${d.worktreePath}\``,
+        d.stuckReason ? `Stuck reason: ${d.stuckReason}` : "",
+        d.agentSessionId ? `Session: ${d.agentSessionId}` : "",
+    ].filter(Boolean);
+    return { text: lines.join("\n") };
+}
+async function handleRetry(id, statePath, api) {
+    const state = await readDispatchState(statePath);
+    const d = getActiveDispatch(state, id);
+    if (!d) {
+        return { text: `No active dispatch found for ${id}.` };
+    }
+    if (d.status !== "stuck") {
+        return { text: `Cannot retry ${id} — status is ${d.status} (must be stuck).` };
+    }
+    // Remove and re-register with reset status
+    await removeActiveDispatch(id, statePath);
+    const retryDispatch = {
+        ...d,
+        status: "dispatched",
+        stuckReason: undefined,
+        workerSessionKey: undefined,
+        auditSessionKey: undefined,
+        dispatchedAt: new Date().toISOString(),
+    };
+    await registerDispatch(id, retryDispatch, statePath);
+    api.logger.info(`/dispatch retry: ${id} reset from stuck → dispatched`);
+    return { text: `**${id}** reset to dispatched. Will be picked up by next dispatch cycle.` };
+}
+async function handleEscalate(id, reason, statePath, api) {
+    const state = await readDispatchState(statePath);
+    const d = getActiveDispatch(state, id);
+    if (!d) {
+        return { text: `No active dispatch found for ${id}.` };
+    }
+    if (d.status === "stuck" || d.status === "done" || d.status === "failed") {
+        return { text: `Cannot escalate ${id} — already in terminal state: ${d.status}.` };
+    }
+    try {
+        await transitionDispatch(id, d.status, "stuck", { stuckReason: reason }, statePath);
+        api.logger.info(`/dispatch escalate: ${id} → stuck (${reason})`);
+        return { text: `**${id}** escalated to stuck: ${reason}` };
+    }
+    catch (err) {
+        if (err instanceof TransitionError) {
+            return { text: `CAS conflict: ${err.message}` };
+        }
+        return { text: `Error: ${String(err)}` };
+    }
+}

--- a/dist/src/infra/doctor.js
+++ b/dist/src/infra/doctor.js
@@ -1,0 +1,1019 @@
+/**
+ * doctor.ts — Comprehensive health checks for the Linear plugin.
+ *
+ * Usage: openclaw openclaw-linear doctor [--fix] [--json]
+ */
+import { existsSync, readFileSync, statSync, accessSync, unlinkSync, chmodSync, constants } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { execFileSync, spawnSync } from "node:child_process";
+import { resolveLinearToken, LinearAgentApi, AUTH_PROFILES_PATH, LINEAR_GRAPHQL_URL } from "../api/linear-api.js";
+import { readDispatchState, listActiveDispatches, listStaleDispatches, pruneCompleted } from "../pipeline/dispatch-state.js";
+import { loadPrompts, clearPromptCache } from "../pipeline/pipeline.js";
+import { listWorktrees } from "./codex-worktree.js";
+import { loadCodingConfig, resolveCodingBackend } from "../tools/code-tool.js";
+import { getWebhookStatus, provisionWebhook, REQUIRED_RESOURCE_TYPES } from "./webhook-provision.js";
+import { createAgentProfilesFile } from "./shared-profiles.js";
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const AGENT_PROFILES_PATH = join(homedir(), ".openclaw", "agent-profiles.json");
+const VALID_BACKENDS = ["claude", "codex", "gemini"];
+const DEFAULT_BIN_DIR = join(process.env.HOME ?? homedir(), ".npm-global", "bin");
+function resolveCliBins(pluginConfig) {
+    return [
+        ["codex", pluginConfig?.codexBin ?? join(DEFAULT_BIN_DIR, "codex")],
+        ["claude", pluginConfig?.claudeBin ?? join(DEFAULT_BIN_DIR, "claude")],
+        ["gemini", pluginConfig?.geminiBin ?? join(DEFAULT_BIN_DIR, "gemini")],
+    ];
+}
+const STALE_DISPATCH_MS = 2 * 60 * 60_000; // 2 hours
+const OLD_COMPLETED_MS = 7 * 24 * 60 * 60_000; // 7 days
+const LOCK_STALE_MS = 30_000; // 30 seconds
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function pass(label, detail) {
+    return { label, severity: "pass", detail };
+}
+function warn(label, detail, opts) {
+    return { label, severity: "warn", detail, fixable: opts?.fixable || undefined, fix: opts?.fix };
+}
+function fail(label, detail, fix) {
+    return { label, severity: "fail", detail, fix };
+}
+function resolveDispatchStatePath(pluginConfig) {
+    const custom = pluginConfig?.dispatchStatePath;
+    if (!custom)
+        return join(homedir(), ".openclaw", "linear-dispatch-state.json");
+    if (custom.startsWith("~/"))
+        return custom.replace("~", homedir());
+    return custom;
+}
+function resolveWorktreeBaseDir(pluginConfig) {
+    const custom = pluginConfig?.worktreeBaseDir;
+    if (!custom)
+        return join(homedir(), ".openclaw", "worktrees");
+    if (custom.startsWith("~/"))
+        return custom.replace("~", homedir());
+    return custom;
+}
+function resolveBaseRepo(pluginConfig) {
+    return pluginConfig?.codexBaseRepo ?? join(process.env.HOME ?? homedir(), "ai-workspace");
+}
+function loadAgentProfiles() {
+    try {
+        const raw = readFileSync(AGENT_PROFILES_PATH, "utf8");
+        return JSON.parse(raw).agents ?? {};
+    }
+    catch {
+        return {};
+    }
+}
+export async function checkAuth(pluginConfig) {
+    const checks = [];
+    const ctx = {};
+    // Token existence
+    const tokenInfo = resolveLinearToken(pluginConfig);
+    if (tokenInfo.accessToken) {
+        checks.push(pass(`Access token found (source: ${tokenInfo.source})`));
+    }
+    else {
+        checks.push(fail("No access token found", undefined, "Run: openclaw openclaw-linear auth"));
+        // Can't check further without token
+        return { checks, ctx };
+    }
+    // Token expiry
+    if (tokenInfo.expiresAt) {
+        const remaining = tokenInfo.expiresAt - Date.now();
+        if (remaining <= 0) {
+            checks.push(warn("Token expired", undefined, { fix: "Run: openclaw openclaw-linear auth" }));
+        }
+        else {
+            const hours = Math.floor(remaining / 3_600_000);
+            const mins = Math.floor((remaining % 3_600_000) / 60_000);
+            if (remaining < 3_600_000) {
+                checks.push(warn(`Token expires soon (${mins}m remaining)`, undefined, { fix: "Restart the gateway to trigger auto-refresh, or run: openclaw openclaw-linear auth" }));
+            }
+            else {
+                checks.push(pass(`Token not expired (${hours}h ${mins}m remaining)`));
+            }
+        }
+    }
+    // API connectivity
+    try {
+        const authHeader = tokenInfo.refreshToken
+            ? `Bearer ${tokenInfo.accessToken}`
+            : tokenInfo.accessToken;
+        const res = await fetch(LINEAR_GRAPHQL_URL, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                Authorization: authHeader,
+            },
+            body: JSON.stringify({
+                query: `{ viewer { id name } organization { name urlKey } }`,
+            }),
+        });
+        if (!res.ok) {
+            checks.push(fail(`API returned ${res.status} ${res.statusText}`));
+        }
+        else {
+            const payload = await res.json();
+            if (payload.errors?.length) {
+                checks.push(fail(`API error: ${payload.errors[0].message}`));
+            }
+            else {
+                const { viewer, organization } = payload.data;
+                ctx.viewer = viewer;
+                ctx.organization = organization;
+                checks.push(pass(`API connectivity (user: ${viewer.name}, workspace: ${organization.name})`));
+            }
+        }
+    }
+    catch (err) {
+        checks.push(fail(`API unreachable: ${err instanceof Error ? err.message : String(err)}`));
+    }
+    // auth-profiles.json permissions
+    try {
+        const stat = statSync(AUTH_PROFILES_PATH);
+        const mode = stat.mode & 0o777;
+        if (mode === 0o600) {
+            checks.push(pass("auth-profiles.json permissions (600)"));
+        }
+        else {
+            checks.push(warn(`auth-profiles.json permissions (${mode.toString(8)}, expected 600)`, undefined, { fixable: true, fix: "Run: chmod 600 ~/.openclaw/auth-profiles.json" }));
+        }
+    }
+    catch {
+        if (tokenInfo.source === "profile") {
+            checks.push(warn("auth-profiles.json not found (but token resolved from profile?)"));
+        }
+        // If token is from config/env, no auth-profiles.json is fine
+    }
+    // OAuth credentials
+    const clientId = pluginConfig?.clientId ?? process.env.LINEAR_CLIENT_ID;
+    const clientSecret = pluginConfig?.clientSecret ?? process.env.LINEAR_CLIENT_SECRET;
+    if (clientId && clientSecret) {
+        checks.push(pass("OAuth credentials configured"));
+    }
+    else {
+        checks.push(warn("OAuth credentials not configured", "Set LINEAR_CLIENT_ID and LINEAR_CLIENT_SECRET env vars or plugin config"));
+    }
+    return { checks, ctx };
+}
+// ---------------------------------------------------------------------------
+// Section 2: Agent Configuration
+// ---------------------------------------------------------------------------
+export function checkAgentConfig(pluginConfig, fix = false) {
+    const checks = [];
+    // Load profiles
+    let profiles;
+    try {
+        if (!existsSync(AGENT_PROFILES_PATH)) {
+            if (fix) {
+                try {
+                    createAgentProfilesFile({
+                        agentId: "my-agent",
+                        label: "My Agent",
+                        mentionAliases: ["my-agent"],
+                    });
+                    checks.push(pass('agent-profiles.json created with default "my-agent" profile (--fix)'));
+                    checks.push(warn('Customize your agent profile', undefined, { fix: `Edit ${AGENT_PROFILES_PATH} to set your agent's name and aliases, or run: openclaw openclaw-linear setup` }));
+                    // Reload after creation
+                    const raw = readFileSync(AGENT_PROFILES_PATH, "utf8");
+                    profiles = JSON.parse(raw).agents ?? {};
+                    // Continue to remaining checks below
+                }
+                catch (err) {
+                    checks.push(fail("Failed to create agent-profiles.json", err instanceof Error ? err.message : String(err), "Run: openclaw openclaw-linear setup"));
+                    return checks;
+                }
+            }
+            else {
+                checks.push(fail("agent-profiles.json not found", `Expected at: ${AGENT_PROFILES_PATH}`, "Run: openclaw openclaw-linear setup"));
+                return checks;
+            }
+        }
+        else {
+            const raw = readFileSync(AGENT_PROFILES_PATH, "utf8");
+            const parsed = JSON.parse(raw);
+            profiles = parsed.agents ?? {};
+        }
+    }
+    catch (err) {
+        checks.push(fail("agent-profiles.json invalid JSON", err instanceof Error ? err.message : String(err)));
+        return checks;
+    }
+    const agentCount = Object.keys(profiles).length;
+    if (agentCount === 0) {
+        checks.push(fail("agent-profiles.json has no agents", undefined, "Add at least one agent to ~/.openclaw/agent-profiles.json"));
+        return checks;
+    }
+    checks.push(pass(`agent-profiles.json loaded (${agentCount} agent${agentCount > 1 ? "s" : ""})`));
+    // Default agent
+    const defaultEntry = Object.entries(profiles).find(([, p]) => p.isDefault);
+    if (defaultEntry) {
+        checks.push(pass(`Default agent: ${defaultEntry[0]}`));
+    }
+    else {
+        checks.push(warn("No agent has isDefault: true", undefined, { fix: "Add \"isDefault\": true to one agent in ~/.openclaw/agent-profiles.json" }));
+    }
+    // Required fields
+    const missing = [];
+    for (const [id, profile] of Object.entries(profiles)) {
+        if (!profile.label)
+            missing.push(`${id}: missing label`);
+        if (!Array.isArray(profile.mentionAliases) || profile.mentionAliases.length === 0) {
+            missing.push(`${id}: missing or empty mentionAliases`);
+        }
+    }
+    if (missing.length === 0) {
+        checks.push(pass("All agents have required fields"));
+    }
+    else {
+        checks.push(fail(`Agent field issues: ${missing.join("; ")}`, undefined, "Each agent needs at least a \"label\" and \"mentionAliases\" array in agent-profiles.json"));
+    }
+    // defaultAgentId match
+    const configAgentId = pluginConfig?.defaultAgentId;
+    if (configAgentId) {
+        if (profiles[configAgentId]) {
+            checks.push(pass(`defaultAgentId "${configAgentId}" matches a profile`));
+        }
+        else {
+            checks.push(warn(`defaultAgentId "${configAgentId}" not found in agent-profiles.json`, `Available: ${Object.keys(profiles).join(", ")}`));
+        }
+    }
+    // Duplicate aliases
+    const aliasMap = new Map();
+    const dupes = [];
+    for (const [id, profile] of Object.entries(profiles)) {
+        for (const alias of profile.mentionAliases ?? []) {
+            const lower = alias.toLowerCase();
+            if (aliasMap.has(lower)) {
+                dupes.push(`"${alias}" (${aliasMap.get(lower)} and ${id})`);
+            }
+            else {
+                aliasMap.set(lower, id);
+            }
+        }
+    }
+    if (dupes.length === 0) {
+        checks.push(pass("No duplicate mention aliases"));
+    }
+    else {
+        checks.push(warn(`Duplicate aliases: ${dupes.join(", ")}`));
+    }
+    return checks;
+}
+// ---------------------------------------------------------------------------
+// Section 3: Coding Tools
+// ---------------------------------------------------------------------------
+export function checkCodingTools(pluginConfig) {
+    const checks = [];
+    // Load config
+    const config = loadCodingConfig();
+    const hasConfig = !!config.codingTool || !!config.backends;
+    if (hasConfig) {
+        checks.push(pass(`coding-tools.json loaded (default: ${config.codingTool ?? "codex"})`));
+    }
+    else {
+        checks.push(warn("coding-tools.json not found or empty (using defaults)", undefined, { fix: "Create coding-tools.json in the plugin root — see README for format" }));
+    }
+    // Validate default backend
+    const defaultBackend = config.codingTool ?? "codex";
+    if (VALID_BACKENDS.includes(defaultBackend)) {
+        // already reported in the line above
+    }
+    else {
+        checks.push(fail(`Unknown default backend: "${defaultBackend}" (valid: ${VALID_BACKENDS.join(", ")})`));
+    }
+    // Validate per-agent overrides
+    if (config.agentCodingTools) {
+        for (const [agentId, backend] of Object.entries(config.agentCodingTools)) {
+            if (!VALID_BACKENDS.includes(backend)) {
+                checks.push(warn(`Agent "${agentId}" override "${backend}" is not a valid backend`));
+            }
+        }
+    }
+    // CLI availability
+    const cliBins = resolveCliBins(pluginConfig);
+    for (const [name, bin] of cliBins) {
+        try {
+            const raw = execFileSync(bin, ["--version"], {
+                encoding: "utf8",
+                timeout: 15_000,
+                env: { ...process.env, CLAUDECODE: undefined },
+            }).trim();
+            checks.push(pass(`${name}: ${raw || "installed"}`));
+        }
+        catch {
+            try {
+                accessSync(bin, constants.X_OK);
+                checks.push(pass(`${name}: installed (version check skipped)`));
+            }
+            catch {
+                checks.push(warn(`${name}: not found at ${bin}`, undefined, { fix: `Install ${name} or check that it's in your PATH` }));
+            }
+        }
+    }
+    return checks;
+}
+// ---------------------------------------------------------------------------
+// Section 4: Files & Directories
+// ---------------------------------------------------------------------------
+export async function checkFilesAndDirs(pluginConfig, fix = false) {
+    const checks = [];
+    // Dispatch state
+    const statePath = resolveDispatchStatePath(pluginConfig);
+    let dispatchState = null;
+    if (existsSync(statePath)) {
+        try {
+            dispatchState = await readDispatchState(pluginConfig?.dispatchStatePath);
+            const activeCount = Object.keys(dispatchState.dispatches.active).length;
+            const completedCount = Object.keys(dispatchState.dispatches.completed).length;
+            checks.push(pass(`Dispatch state: ${activeCount} active, ${completedCount} completed`));
+        }
+        catch (err) {
+            checks.push(fail("Dispatch state corrupt", err instanceof Error ? err.message : String(err)));
+        }
+    }
+    else {
+        checks.push(pass("Dispatch state: no file yet (will be created on first dispatch)"));
+    }
+    // Stale lock files
+    const lockPath = statePath + ".lock";
+    if (existsSync(lockPath)) {
+        try {
+            const lockStat = statSync(lockPath);
+            const lockAge = Date.now() - lockStat.mtimeMs;
+            if (lockAge > LOCK_STALE_MS) {
+                if (fix) {
+                    unlinkSync(lockPath);
+                    checks.push(pass("Stale lock file removed (--fix)"));
+                }
+                else {
+                    checks.push(warn(`Stale lock file (${Math.round(lockAge / 1000)}s old)`, undefined, { fixable: true, fix: "Run: openclaw openclaw-linear doctor --fix to remove" }));
+                }
+            }
+            else {
+                checks.push(warn(`Lock file active (${Math.round(lockAge / 1000)}s old, may be in use)`));
+            }
+        }
+        catch {
+            checks.push(pass("No stale lock files"));
+        }
+    }
+    else {
+        checks.push(pass("No stale lock files"));
+    }
+    // Worktree base dir
+    const wtBaseDir = resolveWorktreeBaseDir(pluginConfig);
+    if (existsSync(wtBaseDir)) {
+        try {
+            accessSync(wtBaseDir, constants.W_OK);
+            checks.push(pass("Worktree base dir writable"));
+        }
+        catch {
+            checks.push(fail(`Worktree base dir not writable: ${wtBaseDir}`));
+        }
+    }
+    else {
+        checks.push(warn(`Worktree base dir does not exist: ${wtBaseDir}`, "Will be created on first dispatch"));
+    }
+    // Base git repo
+    const baseRepo = resolveBaseRepo(pluginConfig);
+    if (existsSync(baseRepo)) {
+        try {
+            execFileSync("git", ["rev-parse", "--git-dir"], {
+                cwd: baseRepo,
+                encoding: "utf8",
+                timeout: 5_000,
+            });
+            checks.push(pass("Base repo is valid git repo"));
+        }
+        catch {
+            checks.push(fail(`Base repo is not a git repo: ${baseRepo}`, undefined, "Run: git init in the base repo directory, or set codexBaseRepo to a different path"));
+        }
+    }
+    else {
+        checks.push(fail(`Base repo does not exist: ${baseRepo}`, undefined, "Set codexBaseRepo in plugin config to your git repository path"));
+    }
+    // CLAUDE.md in base repo
+    if (existsSync(baseRepo)) {
+        const claudeMdPath = join(baseRepo, "CLAUDE.md");
+        if (existsSync(claudeMdPath)) {
+            try {
+                const stat = statSync(claudeMdPath);
+                const sizeKb = Math.round(stat.size / 1024);
+                checks.push(pass(`CLAUDE.md found in base repo (${sizeKb}KB)`));
+            }
+            catch {
+                checks.push(pass("CLAUDE.md found in base repo"));
+            }
+        }
+        else {
+            checks.push(warn("No CLAUDE.md in base repo", `Expected at: ${claudeMdPath}`, {
+                fix: [
+                    `Create ${claudeMdPath} — this is how agents learn your project.`,
+                    "",
+                    "Template:",
+                    "  # Project Name",
+                    "",
+                    "  ## Tech Stack",
+                    "  - Language/framework here",
+                    "",
+                    "  ## Build",
+                    "  ```bash",
+                    "  your build command here",
+                    "  ```",
+                    "",
+                    "  ## Test",
+                    "  ```bash",
+                    "  your test command here",
+                    "  ```",
+                    "",
+                    "  ## Architecture",
+                    "  Brief description of directory structure and key patterns.",
+                ].join("\n"),
+            }));
+        }
+    }
+    // AGENTS.md in base repo
+    if (existsSync(baseRepo)) {
+        const agentsMdPath = join(baseRepo, "AGENTS.md");
+        if (existsSync(agentsMdPath)) {
+            try {
+                const stat = statSync(agentsMdPath);
+                const sizeKb = Math.round(stat.size / 1024);
+                checks.push(pass(`AGENTS.md found in base repo (${sizeKb}KB)`));
+            }
+            catch {
+                checks.push(pass("AGENTS.md found in base repo"));
+            }
+        }
+        else {
+            checks.push(warn("No AGENTS.md in base repo", `Expected at: ${agentsMdPath}`, {
+                fix: [
+                    `Create ${agentsMdPath} — this tells agents how to work on your project.`,
+                    "",
+                    "Template:",
+                    "  # Agent Guidelines",
+                    "",
+                    "  ## Code Style",
+                    "  - Patterns and conventions to follow",
+                    "",
+                    "  ## Workflow",
+                    "  - Branch naming, commit messages, PR process",
+                    "",
+                    "  ## Do / Don't",
+                    "  - Rules agents must follow in this codebase",
+                ].join("\n"),
+            }));
+        }
+    }
+    // Multi-repo path validation
+    const repos = pluginConfig?.repos;
+    if (repos && typeof repos === "object") {
+        for (const [name, repoPath] of Object.entries(repos)) {
+            if (typeof repoPath !== "string")
+                continue;
+            const resolved = repoPath.startsWith("~/") ? repoPath.replace("~", homedir()) : repoPath;
+            if (!existsSync(resolved)) {
+                checks.push(fail(`Repo "${name}": path does not exist: ${resolved}`, undefined, `Verify the path in plugin config repos.${name}, or create the directory and run: git init ${resolved}`));
+            }
+            else {
+                try {
+                    execFileSync("git", ["rev-parse", "--git-dir"], { cwd: resolved, encoding: "utf8", timeout: 5_000 });
+                    checks.push(pass(`Repo "${name}": valid git repo`));
+                }
+                catch {
+                    checks.push(fail(`Repo "${name}": not a git repo at ${resolved}`, undefined, `Run: git init ${resolved}`));
+                }
+            }
+        }
+    }
+    // Prompts
+    try {
+        clearPromptCache();
+        const loaded = loadPrompts(pluginConfig);
+        const errors = [];
+        const sections = [
+            ["worker.system", loaded.worker?.system],
+            ["worker.task", loaded.worker?.task],
+            ["audit.system", loaded.audit?.system],
+            ["audit.task", loaded.audit?.task],
+            ["rework.addendum", loaded.rework?.addendum],
+        ];
+        let sectionCount = 0;
+        for (const [name, value] of sections) {
+            if (value)
+                sectionCount++;
+            else
+                errors.push(`Missing ${name}`);
+        }
+        const requiredVars = ["{{identifier}}", "{{title}}", "{{description}}", "{{worktreePath}}"];
+        let varCount = 0;
+        for (const v of requiredVars) {
+            const inWorker = loaded.worker?.task?.includes(v);
+            const inAudit = loaded.audit?.task?.includes(v);
+            if (inWorker && inAudit) {
+                varCount++;
+            }
+            else {
+                if (!inWorker)
+                    errors.push(`worker.task missing ${v}`);
+                if (!inAudit)
+                    errors.push(`audit.task missing ${v}`);
+            }
+        }
+        if (errors.length === 0) {
+            checks.push(pass(`Prompts valid (${sectionCount}/5 sections, ${varCount}/4 variables)`));
+        }
+        else {
+            checks.push(fail(`Prompt issues: ${errors.join("; ")}`, undefined, "Run: openclaw openclaw-linear prompts validate for details"));
+        }
+    }
+    catch (err) {
+        checks.push(fail("Failed to load prompts", err instanceof Error ? err.message : String(err)));
+    }
+    return checks;
+}
+// ---------------------------------------------------------------------------
+// Section 5: Connectivity
+// ---------------------------------------------------------------------------
+export async function checkConnectivity(pluginConfig, authCtx) {
+    const checks = [];
+    // Linear API (share result from auth check if available)
+    if (authCtx?.viewer) {
+        checks.push(pass("Linear API: connected"));
+    }
+    else {
+        // Re-check if auth context wasn't passed
+        const tokenInfo = resolveLinearToken(pluginConfig);
+        if (tokenInfo.accessToken) {
+            try {
+                const authHeader = tokenInfo.refreshToken
+                    ? `Bearer ${tokenInfo.accessToken}`
+                    : tokenInfo.accessToken;
+                const res = await fetch(LINEAR_GRAPHQL_URL, {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json", Authorization: authHeader },
+                    body: JSON.stringify({ query: `{ viewer { id } }` }),
+                });
+                if (res.ok) {
+                    checks.push(pass("Linear API: connected"));
+                }
+                else {
+                    checks.push(fail(`Linear API: ${res.status} ${res.statusText}`));
+                }
+            }
+            catch (err) {
+                checks.push(fail(`Linear API: unreachable (${err instanceof Error ? err.message : String(err)})`));
+            }
+        }
+        else {
+            checks.push(fail("Linear API: no token available", undefined, "Run: openclaw openclaw-linear auth"));
+        }
+    }
+    // Notification targets
+    const notifRaw = pluginConfig?.notifications;
+    const notifTargets = notifRaw?.targets ?? [];
+    if (notifTargets.length === 0) {
+        checks.push(pass("Notifications: not configured (skipped)"));
+    }
+    else {
+        for (const t of notifTargets) {
+            checks.push(pass(`Notifications: ${t.channel} → ${t.target}`));
+        }
+    }
+    // Webhook self-test
+    const gatewayPort = process.env.OPENCLAW_GATEWAY_PORT ?? "18789";
+    try {
+        const res = await fetch(`http://localhost:${gatewayPort}/linear/webhook`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ type: "test", action: "ping" }),
+        });
+        const body = await res.text();
+        if (res.ok && body === "ok") {
+            checks.push(pass("Webhook self-test: responds OK"));
+        }
+        else {
+            checks.push(warn(`Webhook self-test: ${res.status} — ${body.slice(0, 100)}`));
+        }
+    }
+    catch {
+        checks.push(warn(`Webhook self-test: skipped (gateway not detected on :${gatewayPort})`));
+    }
+    return checks;
+}
+// ---------------------------------------------------------------------------
+// Section 6: Dispatch Health
+// ---------------------------------------------------------------------------
+export async function checkDispatchHealth(pluginConfig, fix = false) {
+    const checks = [];
+    const statePath = resolveDispatchStatePath(pluginConfig);
+    let state;
+    try {
+        state = await readDispatchState(pluginConfig?.dispatchStatePath);
+    }
+    catch {
+        checks.push(pass("Dispatch health: no state file (nothing to check)"));
+        return checks;
+    }
+    // Active dispatches by status
+    const active = listActiveDispatches(state);
+    if (active.length === 0) {
+        checks.push(pass("No active dispatches"));
+    }
+    else {
+        const byStatus = new Map();
+        for (const d of active) {
+            byStatus.set(d.status, (byStatus.get(d.status) ?? 0) + 1);
+        }
+        const parts = Array.from(byStatus.entries()).map(([s, n]) => `${n} ${s}`);
+        const hasStuck = byStatus.has("stuck");
+        if (hasStuck) {
+            checks.push(warn(`Active dispatches: ${parts.join(", ")}`));
+        }
+        else {
+            checks.push(pass(`Active dispatches: ${parts.join(", ")}`));
+        }
+    }
+    // Stale dispatches
+    const stale = listStaleDispatches(state, STALE_DISPATCH_MS);
+    if (stale.length === 0) {
+        checks.push(pass("No stale dispatches"));
+    }
+    else {
+        const ids = stale.map((d) => d.issueIdentifier).join(", ");
+        checks.push(warn(`${stale.length} stale dispatch${stale.length > 1 ? "es" : ""}: ${ids}`, undefined, { fix: "Re-assign the issue to retry, or run: openclaw openclaw-linear doctor --fix to clean up" }));
+    }
+    // Orphaned worktrees
+    try {
+        const worktrees = listWorktrees({ baseDir: resolveWorktreeBaseDir(pluginConfig) });
+        const activeIds = new Set(Object.keys(state.dispatches.active));
+        const orphaned = worktrees.filter((wt) => !activeIds.has(wt.issueIdentifier));
+        if (orphaned.length === 0) {
+            checks.push(pass("No orphaned worktrees"));
+        }
+        else {
+            checks.push(warn(`${orphaned.length} orphaned worktree${orphaned.length > 1 ? "s" : ""} (not in active dispatches)`, orphaned.map((w) => w.path).join(", ")));
+        }
+    }
+    catch {
+        // Worktree listing may fail if dir doesn't exist — that's fine
+    }
+    // Old completed dispatches
+    const completed = Object.values(state.dispatches.completed);
+    const now = Date.now();
+    const old = completed.filter((c) => {
+        const age = now - new Date(c.completedAt).getTime();
+        return age > OLD_COMPLETED_MS;
+    });
+    if (old.length === 0) {
+        checks.push(pass("No old completed dispatches"));
+    }
+    else {
+        if (fix) {
+            const pruned = await pruneCompleted(OLD_COMPLETED_MS, pluginConfig?.dispatchStatePath);
+            checks.push(pass(`Pruned ${pruned} old completed dispatch${pruned > 1 ? "es" : ""} (--fix)`));
+        }
+        else {
+            checks.push(warn(`${old.length} completed dispatch${old.length > 1 ? "es" : ""} older than 7 days`, undefined, { fixable: true, fix: "Run: openclaw openclaw-linear doctor --fix to clean up old entries" }));
+        }
+    }
+    return checks;
+}
+// ---------------------------------------------------------------------------
+// Section 7: Webhook Configuration
+// ---------------------------------------------------------------------------
+export async function checkWebhooks(pluginConfig, fix = false) {
+    const checks = [];
+    const tokenInfo = resolveLinearToken(pluginConfig);
+    if (!tokenInfo.accessToken) {
+        checks.push(warn("Webhook check skipped (no Linear token)"));
+        return checks;
+    }
+    const linearApi = new LinearAgentApi(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+    });
+    const webhookUrl = pluginConfig?.webhookUrl
+        ?? "https://linear.calltelemetry.com/linear/webhook";
+    try {
+        const status = await getWebhookStatus(linearApi, webhookUrl);
+        if (!status) {
+            if (fix) {
+                const result = await provisionWebhook(linearApi, webhookUrl, { allPublicTeams: true });
+                checks.push(pass(`Workspace webhook created (${result.webhookId}) (--fix)`));
+            }
+            else {
+                checks.push(fail(`No workspace webhook found for ${webhookUrl}`, undefined, 'Run: openclaw openclaw-linear webhooks setup'));
+            }
+            return checks;
+        }
+        if (status.issues.length === 0) {
+            checks.push(pass(`Workspace webhook OK (${[...REQUIRED_RESOURCE_TYPES].join(", ")})`));
+        }
+        else {
+            if (fix) {
+                const result = await provisionWebhook(linearApi, webhookUrl);
+                const changes = result.changes?.join(", ") ?? "fixed";
+                checks.push(pass(`Workspace webhook fixed: ${changes} (--fix)`));
+            }
+            else {
+                for (const issue of status.issues) {
+                    checks.push(warn(`Webhook issue: ${issue}`, undefined, { fixable: true, fix: 'Run: openclaw openclaw-linear webhooks setup' }));
+                }
+            }
+        }
+    }
+    catch (err) {
+        checks.push(warn(`Webhook check failed: ${err instanceof Error ? err.message : String(err)}`));
+    }
+    return checks;
+}
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+export async function runDoctor(opts) {
+    const sections = [];
+    // 1. Auth (also captures context for connectivity)
+    const auth = await checkAuth(opts.pluginConfig);
+    sections.push({ name: "Authentication & Tokens", checks: auth.checks });
+    // 2. Agent config
+    sections.push({ name: "Agent Configuration", checks: checkAgentConfig(opts.pluginConfig, opts.fix) });
+    // 3. Coding tools
+    sections.push({ name: "Coding Tools", checks: checkCodingTools(opts.pluginConfig) });
+    // 4. Files & dirs
+    sections.push({
+        name: "Files & Directories",
+        checks: await checkFilesAndDirs(opts.pluginConfig, opts.fix),
+    });
+    // 5. Connectivity (pass auth context to avoid double API call)
+    sections.push({
+        name: "Connectivity",
+        checks: await checkConnectivity(opts.pluginConfig, auth.ctx),
+    });
+    // 6. Dispatch health
+    sections.push({
+        name: "Dispatch Health",
+        checks: await checkDispatchHealth(opts.pluginConfig, opts.fix),
+    });
+    // 7. Webhook configuration (auto-fix if --fix)
+    sections.push({
+        name: "Webhook Configuration",
+        checks: await checkWebhooks(opts.pluginConfig, opts.fix),
+    });
+    // Fix: chmod auth-profiles.json if needed
+    if (opts.fix) {
+        const permCheck = auth.checks.find((c) => c.fixable && c.label.includes("permissions"));
+        if (permCheck) {
+            try {
+                chmodSync(AUTH_PROFILES_PATH, 0o600);
+                permCheck.severity = "pass";
+                permCheck.label = "auth-profiles.json permissions fixed to 600 (--fix)";
+                permCheck.fixable = undefined;
+            }
+            catch { /* best effort */ }
+        }
+    }
+    return { sections, summary: buildSummary(sections) };
+}
+/**
+ * Resolve configured coding backends into concrete CLI probes.
+ */
+function resolveBackendSpecs(pluginConfig) {
+    const binDir = join(process.env.HOME ?? homedir(), ".npm-global", "bin");
+    return [
+        {
+            id: "claude",
+            label: "Claude Code (Anthropic)",
+            bin: pluginConfig?.claudeBin ?? join(binDir, "claude"),
+            testArgs: ["--print", "-p", "Respond with the single word hello", "--output-format", "stream-json", "--max-turns", "1", "--dangerously-skip-permissions"],
+            envKeys: ["ANTHROPIC_API_KEY"],
+            configKey: "claudeApiKey",
+            unsetEnv: ["CLAUDECODE"],
+        },
+        {
+            id: "codex",
+            label: "Codex (OpenAI)",
+            bin: pluginConfig?.codexBin ?? join(binDir, "codex"),
+            testArgs: ["exec", "--json", "--ephemeral", "--full-auto", "echo hello"],
+            envKeys: ["OPENAI_API_KEY"],
+        },
+        {
+            id: "gemini",
+            label: "Gemini CLI (Google)",
+            bin: pluginConfig?.geminiBin ?? join(binDir, "gemini"),
+            testArgs: ["-p", "Respond with the single word hello", "-o", "stream-json", "--yolo"],
+            envKeys: ["GEMINI_API_KEY", "GOOGLE_API_KEY", "GOOGLE_GENAI_API_KEY"],
+        },
+    ];
+}
+/**
+ * Check that a backend binary exists and can report a version.
+ */
+function checkBackendBinary(spec) {
+    const checks = [];
+    // Binary existence
+    try {
+        accessSync(spec.bin, constants.X_OK);
+    }
+    catch {
+        checks.push(fail(`Binary: not found at ${spec.bin}`, undefined, `Install ${spec.id}: npm install -g <package>`));
+        return { installed: false, checks };
+    }
+    // Version check
+    try {
+        const env = { ...process.env };
+        for (const key of spec.unsetEnv ?? [])
+            delete env[key];
+        const raw = execFileSync(spec.bin, ["--version"], {
+            encoding: "utf8",
+            timeout: 15_000,
+            env: env,
+        }).trim();
+        checks.push(pass(`Binary: ${raw || "installed"} (${spec.bin})`));
+    }
+    catch {
+        checks.push(pass(`Binary: installed (${spec.bin})`));
+    }
+    return { installed: true, checks };
+}
+/**
+ * Verify that the backend has an API key from plugin config or environment.
+ */
+function checkBackendApiKey(spec, pluginConfig) {
+    // Check plugin config first
+    if (spec.configKey) {
+        const configVal = pluginConfig?.[spec.configKey];
+        if (typeof configVal === "string" && configVal) {
+            return pass(`API key: configured (${spec.configKey} in plugin config)`);
+        }
+    }
+    // Check env vars
+    for (const envKey of spec.envKeys) {
+        if (process.env[envKey]) {
+            return pass(`API key: configured (${envKey})`);
+        }
+    }
+    return warn(`API key: not found`, `Checked: ${spec.envKeys.join(", ")}${spec.configKey ? `, pluginConfig.${spec.configKey}` : ""}`, { fix: `Set ${spec.envKeys[0]} environment variable or configure in plugin config` });
+}
+/**
+ * Execute a bounded live CLI call for a backend that has an installed binary.
+ */
+function checkBackendLive(spec, pluginConfig) {
+    const env = { ...process.env };
+    for (const key of spec.unsetEnv ?? [])
+        delete env[key];
+    // Pass API key from plugin config if available (Claude-specific)
+    if (spec.configKey) {
+        const configVal = pluginConfig?.[spec.configKey];
+        if (configVal && spec.envKeys[0]) {
+            env[spec.envKeys[0]] = configVal;
+        }
+    }
+    const start = Date.now();
+    try {
+        const result = spawnSync(spec.bin, spec.testArgs, {
+            encoding: "utf8",
+            timeout: 30_000,
+            env: env,
+            stdio: ["ignore", "pipe", "pipe"],
+        });
+        const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+        if (result.error) {
+            const msg = result.error.message ?? String(result.error);
+            if (msg.includes("ETIMEDOUT") || msg.includes("timed out")) {
+                return warn(`Live test: timed out after 30s`);
+            }
+            return warn(`Live test: spawn error — ${msg.slice(0, 200)}`);
+        }
+        if (result.status === 0) {
+            return pass(`Live test: responded in ${elapsed}s`);
+        }
+        // Non-zero exit
+        const stderr = (result.stderr ?? "").trim().slice(0, 200);
+        const stdout = (result.stdout ?? "").trim().slice(0, 200);
+        const detail = stderr || stdout || "(no output)";
+        return warn(`Live test: exit code ${result.status} (${elapsed}s) — ${detail}`);
+    }
+    catch (err) {
+        const elapsed = ((Date.now() - start) / 1000).toFixed(1);
+        return warn(`Live test: error (${elapsed}s) — ${err instanceof Error ? err.message.slice(0, 200) : String(err)}`);
+    }
+}
+/**
+ * Deep health checks for coding tool backends.
+ *
+ * Verifies binary installation, API key configuration, and live callability
+ * for each backend (Claude, Codex, Gemini). Also shows agent routing.
+ *
+ * Usage: openclaw openclaw-linear code-run doctor [--json]
+ */
+export async function checkCodeRunDeep(pluginConfig) {
+    const sections = [];
+    const config = loadCodingConfig();
+    let callableCount = 0;
+    const backendSpecs = resolveBackendSpecs(pluginConfig);
+    for (const spec of backendSpecs) {
+        const checks = [];
+        // 1. Binary check
+        const { installed, checks: binChecks } = checkBackendBinary(spec);
+        checks.push(...binChecks);
+        // API key checks do not depend on the CLI binary being present, and keeping
+        // them visible makes doctor output stable across fresh machines.
+        checks.push(checkBackendApiKey(spec, pluginConfig));
+        if (installed) {
+            // 3. Live invocation test
+            const liveResult = checkBackendLive(spec, pluginConfig);
+            checks.push(liveResult);
+            if (liveResult.severity === "pass")
+                callableCount++;
+        }
+        else {
+            checks.push(warn("Live test: skipped (binary missing)"));
+        }
+        sections.push({ name: `Code Run: ${spec.label}`, checks });
+    }
+    // Routing summary section
+    const routingChecks = [];
+    const defaultBackend = resolveCodingBackend(config);
+    routingChecks.push(pass(`Default backend: ${defaultBackend}`));
+    const profiles = loadAgentProfiles();
+    for (const [agentId, profile] of Object.entries(profiles)) {
+        const resolved = resolveCodingBackend(config, agentId);
+        const isOverride = config.agentCodingTools?.[agentId] != null;
+        const label = profile.label ?? agentId;
+        routingChecks.push(pass(`${label} → ${resolved}${isOverride ? " (override)" : " (default)"}`));
+    }
+    routingChecks.push(pass(`Callable backends: ${callableCount}/${backendSpecs.length}`));
+    sections.push({ name: "Code Run: Routing", checks: routingChecks });
+    return sections;
+}
+// ---------------------------------------------------------------------------
+// Formatters
+// ---------------------------------------------------------------------------
+function icon(severity) {
+    const isTTY = process.stdout?.isTTY;
+    switch (severity) {
+        case "pass": return isTTY ? "\x1b[32m✓\x1b[0m" : "✓";
+        case "warn": return isTTY ? "\x1b[33m⚠\x1b[0m" : "⚠";
+        case "fail": return isTTY ? "\x1b[31m✗\x1b[0m" : "✗";
+    }
+}
+export function formatReport(report) {
+    const lines = [];
+    const bar = "═".repeat(40);
+    lines.push("");
+    lines.push("Linear Plugin Doctor");
+    lines.push(bar);
+    for (const section of report.sections) {
+        lines.push("");
+        lines.push(section.name);
+        for (const check of section.checks) {
+            lines.push(`  ${icon(check.severity)} ${check.label}`);
+            if (check.fix && check.severity !== "pass") {
+                lines.push(`    → ${check.fix}`);
+            }
+        }
+    }
+    lines.push("");
+    lines.push(bar);
+    const { passed, warnings, errors } = report.summary;
+    const parts = [];
+    parts.push(`${passed} passed`);
+    if (warnings > 0)
+        parts.push(`${warnings} warning${warnings > 1 ? "s" : ""}`);
+    if (errors > 0)
+        parts.push(`${errors} error${errors > 1 ? "s" : ""}`);
+    lines.push(`Results: ${parts.join(", ")}`);
+    lines.push("");
+    return lines.join("\n");
+}
+export function formatReportJson(report) {
+    return JSON.stringify(report, null, 2);
+}
+/** Build a summary by counting pass/warn/fail across sections. */
+export function buildSummary(sections) {
+    let passed = 0, warnings = 0, errors = 0;
+    for (const section of sections) {
+        for (const check of section.checks) {
+            switch (check.severity) {
+                case "pass":
+                    passed++;
+                    break;
+                case "warn":
+                    warnings++;
+                    break;
+                case "fail":
+                    errors++;
+                    break;
+            }
+        }
+    }
+    return { passed, warnings, errors };
+}

--- a/dist/src/infra/file-lock.js
+++ b/dist/src/infra/file-lock.js
@@ -1,0 +1,53 @@
+/**
+ * file-lock.ts — Shared file-level locking for state files.
+ *
+ * Used by dispatch-state.ts and planning-state.ts to prevent
+ * concurrent read-modify-write races on JSON state files.
+ */
+import fs from "node:fs/promises";
+const LOCK_STALE_MS = 30_000;
+const LOCK_RETRY_MS = 50;
+const LOCK_TIMEOUT_MS = 10_000;
+function lockPath(statePath) {
+    return statePath + ".lock";
+}
+export async function acquireLock(statePath) {
+    const lock = lockPath(statePath);
+    const deadline = Date.now() + LOCK_TIMEOUT_MS;
+    while (Date.now() < deadline) {
+        try {
+            await fs.writeFile(lock, String(Date.now()), { flag: "wx" });
+            return;
+        }
+        catch (err) {
+            if (err.code !== "EEXIST")
+                throw err;
+            // Check for stale lock
+            try {
+                const content = await fs.readFile(lock, "utf-8");
+                const lockTime = Number(content);
+                if (Date.now() - lockTime > LOCK_STALE_MS) {
+                    try {
+                        await fs.unlink(lock);
+                    }
+                    catch { /* race */ }
+                    continue;
+                }
+            }
+            catch { /* lock disappeared — retry */ }
+            await new Promise((r) => setTimeout(r, LOCK_RETRY_MS));
+        }
+    }
+    // Last resort: force remove potentially stale lock
+    try {
+        await fs.unlink(lockPath(statePath));
+    }
+    catch { /* ignore */ }
+    await fs.writeFile(lock, String(Date.now()), { flag: "wx" });
+}
+export async function releaseLock(statePath) {
+    try {
+        await fs.unlink(lockPath(statePath));
+    }
+    catch { /* already removed */ }
+}

--- a/dist/src/infra/multi-repo.js
+++ b/dist/src/infra/multi-repo.js
@@ -1,0 +1,138 @@
+/**
+ * multi-repo.ts — Multi-repo resolution for dispatches spanning multiple git repos.
+ *
+ * Four-tier resolution:
+ * 1. Issue body markers: <!-- repos: api, frontend --> or [repos: api, frontend]
+ * 2. Linear labels: repo:api, repo:frontend
+ * 3. Team mapping: teamMappings[teamKey].repos from plugin config
+ * 4. Config default: Falls back to single codexBaseRepo
+ */
+import { existsSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import path from "node:path";
+/**
+ * Parse the repos config, normalizing both string and object formats.
+ * String values become { path: value }, objects pass through.
+ */
+export function getRepoEntries(pluginConfig) {
+    const repos = pluginConfig?.repos;
+    if (!repos)
+        return {};
+    const result = {};
+    for (const [name, value] of Object.entries(repos)) {
+        if (typeof value === "string") {
+            result[name] = { path: value };
+        }
+        else if (value && typeof value === "object") {
+            result[name] = {
+                path: value.path,
+                github: value.github,
+                hostname: value.hostname,
+            };
+        }
+    }
+    return result;
+}
+/**
+ * Build candidate repositories for Linear's issueRepositorySuggestions API.
+ * Extracts GitHub identity from enriched repo entries.
+ */
+export function buildCandidateRepositories(pluginConfig) {
+    const entries = getRepoEntries(pluginConfig);
+    return Object.values(entries)
+        .filter(e => e.github)
+        .map(e => ({
+        hostname: e.hostname ?? "github.com",
+        repositoryFullName: e.github,
+    }));
+}
+/**
+ * Resolve which repos a dispatch should work with.
+ */
+export function resolveRepos(description, labels, pluginConfig, teamKey) {
+    // 1. Check issue body for repo markers
+    // Match: <!-- repos: name1, name2 --> or [repos: name1, name2]
+    const htmlComment = description?.match(/<!--\s*repos:\s*([^>]+?)\s*-->/i);
+    const bracketMatch = description?.match(/\[repos:\s*([^\]]+)\]/i);
+    const bodyMatch = htmlComment?.[1] ?? bracketMatch?.[1];
+    if (bodyMatch) {
+        const names = bodyMatch.split(",").map(s => s.trim()).filter(Boolean);
+        if (names.length > 0) {
+            const repoMap = getRepoMap(pluginConfig);
+            const repos = names.map(name => ({
+                name,
+                path: repoMap[name] ?? resolveRepoPath(name, pluginConfig),
+            }));
+            return { repos, source: "issue_body" };
+        }
+    }
+    // 2. Check labels for repo: prefix
+    const repoLabels = labels
+        .filter(l => l.startsWith("repo:"))
+        .map(l => l.slice(5).trim())
+        .filter(Boolean);
+    if (repoLabels.length > 0) {
+        const repoMap = getRepoMap(pluginConfig);
+        const repos = repoLabels.map(name => ({
+            name,
+            path: repoMap[name] ?? resolveRepoPath(name, pluginConfig),
+        }));
+        return { repos, source: "labels" };
+    }
+    // 3. Team mapping: teamMappings[teamKey].repos
+    if (teamKey) {
+        const teamMappings = pluginConfig?.teamMappings;
+        const teamRepoNames = teamMappings?.[teamKey]?.repos;
+        if (teamRepoNames && teamRepoNames.length > 0) {
+            const repoMap = getRepoMap(pluginConfig);
+            const repos = teamRepoNames.map(name => ({
+                name,
+                path: repoMap[name] ?? resolveRepoPath(name, pluginConfig),
+            }));
+            return { repos, source: "team_mapping" };
+        }
+    }
+    // 4. Config default: single repo
+    const baseRepo = pluginConfig?.codexBaseRepo ?? path.join(homedir(), "ai-workspace");
+    return {
+        repos: [{ name: "default", path: baseRepo }],
+        source: "config_default",
+    };
+}
+function getRepoMap(pluginConfig) {
+    const entries = getRepoEntries(pluginConfig);
+    const result = {};
+    for (const [name, entry] of Object.entries(entries)) {
+        result[name] = entry.path;
+    }
+    return result;
+}
+function resolveRepoPath(name, pluginConfig) {
+    // Convention: {parentDir}/{name}
+    const baseRepo = pluginConfig?.codexBaseRepo ?? path.join(homedir(), "ai-workspace");
+    const parentDir = path.dirname(baseRepo);
+    return path.join(parentDir, name);
+}
+export function isMultiRepo(resolution) {
+    return resolution.repos.length > 1;
+}
+/**
+ * Validate a repo path: exists, is a git repo, and whether it's a submodule.
+ * Submodules have a `.git` *file* (not directory) that points to the parent's
+ * `.git/modules/` — `git worktree add` won't work on them.
+ */
+export function validateRepoPath(repoPath) {
+    if (!existsSync(repoPath)) {
+        return { exists: false, isGitRepo: false, isSubmodule: false };
+    }
+    const gitPath = path.join(repoPath, ".git");
+    if (!existsSync(gitPath)) {
+        return { exists: true, isGitRepo: false, isSubmodule: false };
+    }
+    const stat = statSync(gitPath);
+    if (stat.isFile()) {
+        // .git is a file → submodule (points to parent's .git/modules/)
+        return { exists: true, isGitRepo: true, isSubmodule: true };
+    }
+    return { exists: true, isGitRepo: true, isSubmodule: false };
+}

--- a/dist/src/infra/notify.js
+++ b/dist/src/infra/notify.js
@@ -1,0 +1,297 @@
+/**
+ * notify.ts — Unified notification provider for dispatch lifecycle events.
+ *
+ * Routes through OpenClaw's outbound delivery for all providers (Discord,
+ * Slack, Telegram, Signal, etc). Two delivery paths:
+ *
+ *   1. **In-process** — calls `deliverOutboundPayloads` from the gateway's
+ *      bundled outbound runtime. Fast (no subprocess), supports Telegram
+ *      HTML and Discord channelData embeds. Resolved lazily at first call by
+ *      scanning `openclaw/dist/deliver-*.js` for the matching export, since
+ *      the bundle file name carries a build-time hash and is not in
+ *      package.json `exports`.
+ *
+ *   2. **CLI subprocess fallback** — `openclaw message send …` via async
+ *      `execFile`. Used when the in-process resolver can't find a matching
+ *      `deliver-*.js` (e.g. an openclaw upgrade renamed bundles in a way the
+ *      regex doesn't catch) or when the in-process call throws.
+ *
+ * 2026.4 dropped the per-channel `runtime.channel.<id>.sendMessage*` surface
+ * and the public `plugin-sdk` does not re-export `deliverOutboundPayloads`,
+ * so the only stable entrypoint is the CLI fallback. The in-process path is
+ * a best-effort optimization that gracefully degrades.
+ */
+import { execFile } from "node:child_process";
+import { readdir } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { pathToFileURL } from "node:url";
+import { emitDiagnostic } from "./observability.js";
+const execFileAsync = promisify(execFile);
+// ---------------------------------------------------------------------------
+// Unified message formatter
+// ---------------------------------------------------------------------------
+export function formatMessage(kind, payload) {
+    const id = payload.identifier;
+    const attempt = (payload.attempt ?? 0) + 1; // 1-based for humans
+    switch (kind) {
+        case "dispatch":
+            return `${id} started — ${payload.title}`;
+        case "working":
+            return `${id} working on it (attempt ${attempt})`;
+        case "auditing":
+            return `${id} checking the work...`;
+        case "audit_pass":
+            return `✅ ${id} done! Ready for review.`;
+        case "audit_fail": {
+            const issues = payload.verdict?.gaps?.join(", ") ?? "unspecified";
+            return `${id} needs more work (attempt ${attempt}). Issues: ${issues}`;
+        }
+        case "escalation":
+            return `🚨 ${id} needs your help — couldn't fix it after ${attempt} ${attempt === 1 ? "try" : "tries"}`;
+        case "stuck":
+            return `⏰ ${id} stuck — ${payload.reason ?? "inactive for 2h"}`;
+        case "watchdog_kill":
+            return `⚡ ${id} timed out (${payload.reason ?? "no activity for 120s"}). ${payload.attempt != null ? `Retrying (attempt ${attempt}).` : "Will retry."}`;
+        case "project_progress":
+            return `📊 ${payload.title} (${id}): ${payload.status}`;
+        case "project_complete":
+            return `✅ ${payload.title} (${id}): ${payload.status}`;
+        default:
+            return `${id} — ${kind}: ${payload.status}`;
+    }
+}
+// ---------------------------------------------------------------------------
+// Rich message formatter (Discord embeds + Telegram HTML)
+// ---------------------------------------------------------------------------
+const EVENT_COLORS = {
+    dispatch: 0x3498db, // blue
+    working: 0x3498db, // blue
+    auditing: 0xf39c12, // yellow
+    audit_pass: 0x2ecc71, // green
+    audit_fail: 0xe74c3c, // red
+    escalation: 0xe74c3c, // red
+    stuck: 0xe67e22, // orange
+    watchdog_kill: 0x9b59b6, // purple
+    project_progress: 0x3498db,
+    project_complete: 0x2ecc71,
+};
+export function formatRichMessage(kind, payload) {
+    const text = formatMessage(kind, payload);
+    const color = EVENT_COLORS[kind] ?? 0x95a5a6;
+    // Discord embed
+    const fields = [];
+    if (payload.attempt != null)
+        fields.push({ name: "Attempt", value: String((payload.attempt ?? 0) + 1), inline: true });
+    if (payload.status)
+        fields.push({ name: "Status", value: payload.status, inline: true });
+    if (payload.verdict?.gaps?.length) {
+        fields.push({ name: "Issues to fix", value: payload.verdict.gaps.join("\n").slice(0, 1024) });
+    }
+    if (payload.reason)
+        fields.push({ name: "Reason", value: payload.reason });
+    const embed = {
+        title: `${payload.identifier} — ${kind.replace(/_/g, " ")}`,
+        description: payload.title,
+        color,
+        fields: fields.length > 0 ? fields : undefined,
+        footer: { text: `Linear Agent • ${kind}` },
+    };
+    // Telegram HTML
+    const htmlParts = [
+        `<b>${escapeHtml(payload.identifier)}</b> — ${escapeHtml(kind.replace(/_/g, " "))}`,
+        `<i>${escapeHtml(payload.title)}</i>`,
+    ];
+    if (payload.attempt != null)
+        htmlParts.push(`Attempt: <code>${(payload.attempt ?? 0) + 1}</code>`);
+    if (payload.status)
+        htmlParts.push(`Status: <code>${escapeHtml(payload.status)}</code>`);
+    if (payload.verdict?.gaps?.length) {
+        htmlParts.push(`Issues to fix:\n${payload.verdict.gaps.map(g => `• ${escapeHtml(g)}`).join("\n")}`);
+    }
+    if (payload.reason)
+        htmlParts.push(`Reason: ${escapeHtml(payload.reason)}`);
+    return {
+        text,
+        discord: { embeds: [embed] },
+        telegram: { html: htmlParts.join("\n") },
+    };
+}
+function escapeHtml(s) {
+    return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}
+let _deliverModulePromise = null;
+/**
+ * Test seam: reset the cached resolver so unit tests get a fresh probe.
+ * Pass an explicit resolved value to skip the readdir scan entirely (used
+ * by tests that want to force one path or the other).
+ */
+export function _resetDeliverResolver(forceResult) {
+    if (forceResult === undefined) {
+        _deliverModulePromise = null;
+    }
+    else {
+        _deliverModulePromise = Promise.resolve(forceResult);
+    }
+}
+async function resolveInProcessDeliver() {
+    if (_deliverModulePromise)
+        return _deliverModulePromise;
+    _deliverModulePromise = (async () => {
+        try {
+            const _require = createRequire(import.meta.url);
+            const mainEntry = _require.resolve("openclaw");
+            const distDir = dirname(mainEntry);
+            const files = await readdir(distDir);
+            const candidates = files.filter((f) => /^deliver-[A-Za-z0-9_-]+\.js$/.test(f));
+            for (const file of candidates) {
+                try {
+                    const url = pathToFileURL(join(distDir, file)).href;
+                    const mod = (await import(url));
+                    if (typeof mod.deliverOutboundPayloads === "function") {
+                        return mod;
+                    }
+                }
+                catch {
+                    // try next candidate
+                }
+            }
+            return null;
+        }
+        catch {
+            return null;
+        }
+    })();
+    return _deliverModulePromise;
+}
+/** Build a ReplyPayload from a notify message + target. */
+function buildPayload(target, message) {
+    if (typeof message === "string") {
+        return { text: message };
+    }
+    // Rich message — encode per-channel envelopes into channelData. The
+    // outbound adapters consume these:
+    //   • Telegram: `sendTelegramPayloadMessages` reads `channelData.telegram`
+    //     for buttons/quoteText; the adapter hardcodes `textMode: "html"` so
+    //     passing HTML in `text` is rendered with `parse_mode: "HTML"`.
+    //   • Discord: `deliverDiscordInteractionReply` reads
+    //     `channelData.discord.components` for components-V2 envelopes.
+    if (target.channel === "telegram" && message.telegram?.html) {
+        return { text: message.telegram.html };
+    }
+    if (target.channel === "discord" && message.discord?.embeds) {
+        return {
+            text: message.text,
+            channelData: {
+                discord: { embeds: message.discord.embeds },
+            },
+        };
+    }
+    return { text: message.text };
+}
+// ---------------------------------------------------------------------------
+// Unified send
+// ---------------------------------------------------------------------------
+export async function sendToTarget(target, message, runtime) {
+    const ch = target.channel;
+    const isSilent = ch === "telegram" || ch === "discord";
+    // Try in-process delivery first. Falls through to subprocess on any error.
+    const mod = await resolveInProcessDeliver();
+    if (mod) {
+        try {
+            const cfg = await runtime.config.loadConfig();
+            await mod.deliverOutboundPayloads({
+                cfg,
+                channel: ch,
+                to: target.target,
+                accountId: target.accountId,
+                payloads: [buildPayload(target, message)],
+                silent: isSilent,
+            });
+            return;
+        }
+        catch {
+            // Fall through to subprocess on any in-process failure (signature
+            // change, missing channel adapter, etc.). Errors during the actual
+            // send will surface through the subprocess path and the caller's
+            // sanitizer.
+        }
+    }
+    // CLI subprocess fallback
+    const isRich = typeof message !== "string";
+    const plainText = isRich ? message.text : message;
+    const argv = ["message", "send", "--channel", ch, "--target", target.target, "--message", plainText, "--json"];
+    if (target.accountId)
+        argv.push("--account", target.accountId);
+    if (isSilent)
+        argv.push("--silent");
+    if (isRich && ch === "discord" && message.discord?.embeds) {
+        // Discord components-V2 envelope is the only public CLI route for
+        // embeds; the adapter consumes `params.components` via the action runner.
+        argv.push("--components", JSON.stringify({ embeds: message.discord.embeds }));
+    }
+    // CLI cannot pass telegram parse_mode — RichMessage.telegram.html
+    // collapses to plain text on this path. The in-process branch above is
+    // the only way to render Telegram HTML today.
+    await execFileAsync("openclaw", argv, { timeout: 30_000 });
+}
+// ---------------------------------------------------------------------------
+// Config-driven factory
+// ---------------------------------------------------------------------------
+/**
+ * Parse notification config from plugin config.
+ */
+export function parseNotificationsConfig(pluginConfig) {
+    const raw = pluginConfig?.notifications;
+    return {
+        targets: raw?.targets ?? [],
+        events: raw?.events ?? {},
+        richFormat: raw?.richFormat ?? false,
+    };
+}
+/**
+ * Create a notifier from plugin config. Returns a NotifyFn that:
+ * 1. Checks event toggles (skip suppressed events)
+ * 2. Formats the message
+ * 3. Fans out to all configured targets (failures isolated via Promise.allSettled)
+ */
+export function createNotifierFromConfig(pluginConfig, runtime, api) {
+    const config = parseNotificationsConfig(pluginConfig);
+    if (!config.targets?.length)
+        return createNoopNotifier();
+    const useRich = config.richFormat === true;
+    return async (kind, payload) => {
+        // Check event toggle — default is enabled (true)
+        if (config.events?.[kind] === false)
+            return;
+        const message = useRich ? formatRichMessage(kind, payload) : formatMessage(kind, payload);
+        await Promise.allSettled(config.targets.map(async (target) => {
+            try {
+                await sendToTarget(target, message, runtime);
+            }
+            catch (err) {
+                const safeError = err instanceof Error ? err.message : "Unknown error";
+                // Strip potential URLs/tokens from error messages to prevent secret leakage
+                const sanitizedError = safeError
+                    .replace(/https?:\/\/[^\s]+/g, "[URL]")
+                    .replace(/[A-Za-z0-9_-]{20,}/g, "[TOKEN]");
+                console.error(`Notify error (${target.channel}:${target.target}): ${sanitizedError}`);
+                if (api) {
+                    emitDiagnostic(api, {
+                        event: "notify_failed",
+                        identifier: payload.identifier,
+                        phase: kind,
+                        error: sanitizedError,
+                    });
+                }
+            }
+        }));
+    };
+}
+// ---------------------------------------------------------------------------
+// Noop fallback
+// ---------------------------------------------------------------------------
+export function createNoopNotifier() {
+    return async () => { };
+}

--- a/dist/src/infra/observability.js
+++ b/dist/src/infra/observability.js
@@ -1,0 +1,9 @@
+const PREFIX = "[linear:diagnostic]";
+export function emitDiagnostic(api, payload) {
+    try {
+        api.logger.info(`${PREFIX} ${JSON.stringify(payload)}`);
+    }
+    catch {
+        // Never throw from telemetry
+    }
+}

--- a/dist/src/infra/resilience.js
+++ b/dist/src/infra/resilience.js
@@ -1,0 +1,72 @@
+/**
+ * resilience.ts — Retry + circuit breaker for external API calls.
+ *
+ * Wraps functions with exponential backoff retry and a circuit breaker
+ * that opens after consecutive failures to prevent cascading overload.
+ */
+import { retry, handleAll, ExponentialBackoff, circuitBreaker, ConsecutiveBreaker, wrap, } from "cockatiel";
+// ---------------------------------------------------------------------------
+// Retry policy
+// ---------------------------------------------------------------------------
+const DEFAULT_RETRY_ATTEMPTS = 3;
+const DEFAULT_BACKOFF = { initialDelay: 500, maxDelay: 5_000 };
+/**
+ * Create a retry policy with exponential backoff.
+ */
+export function createRetryPolicy(opts) {
+    const attempts = opts?.attempts ?? DEFAULT_RETRY_ATTEMPTS;
+    const initialDelay = opts?.initialDelay ?? DEFAULT_BACKOFF.initialDelay;
+    const maxDelay = opts?.maxDelay ?? DEFAULT_BACKOFF.maxDelay;
+    return retry(handleAll, {
+        maxAttempts: attempts,
+        backoff: new ExponentialBackoff({
+            initialDelay,
+            maxDelay,
+        }),
+    });
+}
+// ---------------------------------------------------------------------------
+// Circuit breaker
+// ---------------------------------------------------------------------------
+const DEFAULT_BREAKER_THRESHOLD = 5;
+const DEFAULT_HALF_OPEN_AFTER = 30_000;
+/**
+ * Create a circuit breaker that opens after consecutive failures.
+ */
+export function createCircuitBreaker(opts) {
+    const threshold = opts?.threshold ?? DEFAULT_BREAKER_THRESHOLD;
+    const halfOpenAfter = opts?.halfOpenAfter ?? DEFAULT_HALF_OPEN_AFTER;
+    return circuitBreaker(handleAll, {
+        breaker: new ConsecutiveBreaker(threshold),
+        halfOpenAfter,
+    });
+}
+// ---------------------------------------------------------------------------
+// Combined policy
+// ---------------------------------------------------------------------------
+let _defaultPolicy = null;
+/**
+ * Get the default combined retry + circuit breaker policy (singleton).
+ * 3 retries with exponential backoff (500ms → 5s) + circuit breaker
+ * (opens after 5 consecutive failures, half-opens after 30s).
+ */
+export function getDefaultPolicy() {
+    if (!_defaultPolicy) {
+        const retryPolicy = createRetryPolicy();
+        const breaker = createCircuitBreaker();
+        _defaultPolicy = wrap(retryPolicy, breaker);
+    }
+    return _defaultPolicy;
+}
+/**
+ * Execute a function with the default retry + circuit breaker policy.
+ */
+export async function withResilience(fn) {
+    return getDefaultPolicy().execute(fn);
+}
+/**
+ * Reset the default policy singleton (for testing).
+ */
+export function resetDefaultPolicy() {
+    _defaultPolicy = null;
+}

--- a/dist/src/infra/shared-profiles.js
+++ b/dist/src/infra/shared-profiles.js
@@ -1,0 +1,160 @@
+/**
+ * shared-profiles.ts — Shared agent profile loader with TTL cache.
+ *
+ * Consolidates the duplicate loadAgentProfiles() / buildMentionPattern() /
+ * resolveAgentFromAlias() implementations that were previously in
+ * webhook.ts, intent-classify.ts, and tier-assess.ts.
+ */
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { homedir } from "node:os";
+// ---------------------------------------------------------------------------
+// Cached profile loader (5s TTL)
+// ---------------------------------------------------------------------------
+export const PROFILES_PATH = join(homedir(), ".openclaw", "agent-profiles.json");
+let profilesCache = null;
+const PROFILES_CACHE_TTL_MS = 5_000;
+export function loadAgentProfiles() {
+    const now = Date.now();
+    if (profilesCache && now - profilesCache.loadedAt < PROFILES_CACHE_TTL_MS) {
+        return profilesCache.data;
+    }
+    try {
+        const raw = readFileSync(PROFILES_PATH, "utf8");
+        const data = JSON.parse(raw).agents ?? {};
+        profilesCache = { data, loadedAt: now };
+        return data;
+    }
+    catch {
+        return {};
+    }
+}
+// ---------------------------------------------------------------------------
+// Mention pattern builder
+// ---------------------------------------------------------------------------
+/**
+ * Build a regex that matches @mentions for all agent mentionAliases.
+ * appAliases are excluded — those trigger AgentSessionEvent instead.
+ */
+export function buildMentionPattern(profiles) {
+    const aliases = [];
+    for (const [, profile] of Object.entries(profiles)) {
+        aliases.push(...profile.mentionAliases);
+    }
+    if (aliases.length === 0)
+        return null;
+    const escaped = aliases.map(a => a.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    return new RegExp(`@(${escaped.join("|")})`, "gi");
+}
+// ---------------------------------------------------------------------------
+// Agent resolver
+// ---------------------------------------------------------------------------
+/**
+ * Given a mention alias string (e.g. "kaylee"), resolve which agent it
+ * belongs to. Returns { agentId, label } or null if no match.
+ */
+export function resolveAgentFromAlias(alias, profiles) {
+    const lower = alias.toLowerCase();
+    for (const [agentId, profile] of Object.entries(profiles)) {
+        if (profile.mentionAliases.some(a => a.toLowerCase() === lower)) {
+            return { agentId, label: profile.label };
+        }
+    }
+    return null;
+}
+// ---------------------------------------------------------------------------
+// Default agent resolver (shared helper for intent-classify / tier-assess)
+// ---------------------------------------------------------------------------
+/**
+ * Resolve the default agent ID from plugin config or agent profiles.
+ * Falls back to "default" if nothing is configured.
+ */
+export function resolveDefaultAgent(api) {
+    const fromConfig = api.pluginConfig?.defaultAgentId;
+    if (typeof fromConfig === "string" && fromConfig)
+        return fromConfig;
+    try {
+        const raw = readFileSync(PROFILES_PATH, "utf8");
+        const profiles = JSON.parse(raw).agents ?? {};
+        const defaultAgent = Object.entries(profiles).find(([, p]) => p.isDefault);
+        if (defaultAgent)
+            return defaultAgent[0];
+    }
+    catch { /* fall through */ }
+    return "default";
+}
+// ---------------------------------------------------------------------------
+// Profile validation — returns a user-facing error string or null if OK.
+// ---------------------------------------------------------------------------
+/**
+ * Validate that agent-profiles.json exists, is parseable, and has at least
+ * one agent.  Returns a human-readable error string suitable for posting
+ * back to Linear, or null when everything looks good.
+ */
+export function validateProfiles() {
+    if (!existsSync(PROFILES_PATH)) {
+        return (`**Critical setup error:** \`agent-profiles.json\` not found.\n\n` +
+            `The Linear plugin requires this file to route messages to your agent.\n\n` +
+            `**Create it now:**\n` +
+            "```\n" +
+            `cat > ${PROFILES_PATH} << 'EOF'\n` +
+            `{\n` +
+            `  "agents": {\n` +
+            `    "my-agent": {\n` +
+            `      "label": "My Agent",\n` +
+            `      "mission": "AI assistant",\n` +
+            `      "isDefault": true,\n` +
+            `      "mentionAliases": ["my-agent"]\n` +
+            `    }\n` +
+            `  }\n` +
+            `}\n` +
+            `EOF\n` +
+            "```\n\n" +
+            `Then restart the gateway: \`systemctl --user restart openclaw-gateway\`\n\n` +
+            `Or run the guided setup: \`openclaw openclaw-linear setup\``);
+    }
+    let profiles;
+    try {
+        const raw = readFileSync(PROFILES_PATH, "utf8");
+        profiles = JSON.parse(raw).agents ?? {};
+    }
+    catch (err) {
+        return (`**Critical setup error:** \`agent-profiles.json\` exists but could not be parsed.\n\n` +
+            `Error: ${err instanceof Error ? err.message : String(err)}\n\n` +
+            `Fix the JSON syntax in \`${PROFILES_PATH}\` and restart the gateway.\n` +
+            `Run \`openclaw openclaw-linear doctor\` to verify.`);
+    }
+    if (Object.keys(profiles).length === 0) {
+        return (`**Critical setup error:** \`agent-profiles.json\` has no agents configured.\n\n` +
+            `Add at least one agent entry to the \`"agents"\` object in \`${PROFILES_PATH}\`.\n` +
+            `Run \`openclaw openclaw-linear setup\` for guided setup.`);
+    }
+    return null;
+}
+/**
+ * Create `agent-profiles.json` with a single default agent.
+ * Creates the parent directory if needed. Throws on write failure.
+ */
+export function createAgentProfilesFile(opts) {
+    const data = {
+        agents: {
+            [opts.agentId]: {
+                label: opts.label,
+                mission: opts.mission ?? "AI assistant for Linear issues",
+                isDefault: true,
+                mentionAliases: opts.mentionAliases,
+            },
+        },
+    };
+    mkdirSync(dirname(PROFILES_PATH), { recursive: true });
+    writeFileSync(PROFILES_PATH, JSON.stringify(data, null, 2) + "\n", "utf8");
+    // Bust the cache so the next load picks up the new file
+    profilesCache = null;
+}
+// ---------------------------------------------------------------------------
+// Test-only: reset cache
+// ---------------------------------------------------------------------------
+/** @internal — test-only; clears the profiles cache. */
+export function _resetProfilesCacheForTesting() {
+    profilesCache = null;
+}

--- a/dist/src/infra/template.js
+++ b/dist/src/infra/template.js
@@ -1,0 +1,17 @@
+/**
+ * template.ts — Shared template renderer for {{key}} interpolation.
+ *
+ * Used by pipeline.ts and planner.ts to render prompt templates with
+ * issue context variables.
+ */
+/**
+ * Replaces all {{key}} occurrences in `template` with corresponding values
+ * from `vars`. Missing keys are replaced with empty string.
+ */
+export function renderTemplate(template, vars) {
+    let result = template;
+    for (const [key, value] of Object.entries(vars)) {
+        result = result.replaceAll(`{{${key}}}`, value ?? "");
+    }
+    return result;
+}

--- a/dist/src/infra/tmux-runner.js
+++ b/dist/src/infra/tmux-runner.js
@@ -1,0 +1,236 @@
+import { execSync, spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import { mkdirSync, writeFileSync, unlinkSync } from "node:fs";
+import { dirname } from "node:path";
+import { formatActivityLogLine, createProgressEmitter } from "../tools/cli-shared.js";
+import { InactivityWatchdog } from "../agent/watchdog.js";
+import { shellEscape } from "./tmux.js";
+const COMPLETION_EVENT_TYPES = new Set([
+    "result",
+    "session.completed",
+    "task_completed",
+    "task.completed",
+    "task_completion",
+]);
+// Track active tmux sessions by issueId
+const activeSessions = new Map();
+/**
+ * Completion detector for streamed CLI JSONL events.
+ * Supports Claude and Codex event variants across releases.
+ */
+export function isCompletionEvent(event) {
+    const type = typeof event?.type === "string" ? event.type.trim().toLowerCase() : "";
+    if (type && COMPLETION_EVENT_TYPES.has(type)) {
+        return true;
+    }
+    const itemType = typeof event?.item?.type === "string" ? event.item.type.trim().toLowerCase() : "";
+    if (itemType && COMPLETION_EVENT_TYPES.has(itemType)) {
+        return true;
+    }
+    return event?.session?.completed === true;
+}
+/**
+ * Get the active tmux session for a given issueId, or null if none.
+ */
+export function getActiveTmuxSession(issueId) {
+    return activeSessions.get(issueId) ?? null;
+}
+/**
+ * Run a command inside a tmux session with output piped to a JSONL log.
+ * Monitors the log file for events and streams them to Linear.
+ *
+ * The command + tee are wrapped in a shell script so that tee runs INSIDE
+ * the tmux session (not in the outer shell). This ensures JSONL output
+ * from the CLI subprocess is captured to the log file.
+ */
+export async function runInTmux(opts) {
+    const { issueId, issueIdentifier, sessionName, command, cwd, timeoutMs, watchdogMs, logPath, mapEvent, linearApi, agentSessionId, steeringMode, logger, onUpdate, progressHeader, } = opts;
+    // Ensure log directory exists
+    mkdirSync(dirname(logPath), { recursive: true });
+    // Touch the log file so tail -f can start immediately
+    writeFileSync(logPath, "", { flag: "a" });
+    // Register active session
+    const session = {
+        sessionName,
+        backend: sessionName.split("-").slice(-2, -1)[0] ?? "unknown",
+        issueIdentifier,
+        issueId,
+        steeringMode,
+    };
+    activeSessions.set(issueId, session);
+    const progress = createProgressEmitter({ header: progressHeader, onUpdate });
+    progress.emitHeader();
+    // Write a shell wrapper script so the entire pipeline (command | tee)
+    // runs inside the tmux session. This avoids quoting hell and ensures
+    // tee captures the subprocess output, not tmux's own stdout.
+    const scriptPath = `${logPath}.run.sh`;
+    try {
+        writeFileSync(scriptPath, [
+            "#!/bin/sh",
+            `exec ${command} 2>&1 | tee -a ${shellEscape(logPath)}`,
+            "",
+        ].join("\n"), { mode: 0o755 });
+        // Start tmux session running the wrapper script
+        execSync(`tmux new-session -d -s ${shellEscape(sessionName)} -c ${shellEscape(cwd)} ${shellEscape(scriptPath)}`, { stdio: "ignore", timeout: 10_000 });
+        logger.info(`tmux session started: ${sessionName} (log: ${logPath})`);
+        // Tail the log file and process JSONL events
+        return await new Promise((resolve) => {
+            const tail = spawn("tail", ["-f", "-n", "+1", logPath], {
+                stdio: ["ignore", "pipe", "ignore"],
+            });
+            let killed = false;
+            let killedByWatchdog = false;
+            let resolved = false;
+            let completionEventReceived = false;
+            const collectedMessages = [];
+            const timer = setTimeout(() => {
+                killed = true;
+                cleanup("timeout");
+            }, timeoutMs);
+            const watchdog = new InactivityWatchdog({
+                inactivityMs: watchdogMs,
+                label: `tmux:${sessionName}`,
+                logger,
+                onKill: () => {
+                    killedByWatchdog = true;
+                    killed = true;
+                    cleanup("inactivity_timeout");
+                },
+            });
+            watchdog.start();
+            function cleanup(reason) {
+                if (resolved)
+                    return;
+                resolved = true;
+                clearTimeout(timer);
+                watchdog.stop();
+                tail.kill();
+                // Kill the tmux session
+                try {
+                    execSync(`tmux kill-session -t ${shellEscape(sessionName)}`, {
+                        stdio: "ignore",
+                        timeout: 5_000,
+                    });
+                }
+                catch { /* session may already be gone */ }
+                // Clean up wrapper script
+                try {
+                    unlinkSync(scriptPath);
+                }
+                catch { /* best effort */ }
+                activeSessions.delete(issueId);
+                const output = collectedMessages.join("\n\n") || "(no output)";
+                if (reason === "inactivity_timeout") {
+                    logger.warn(`tmux session ${sessionName} killed by inactivity watchdog`);
+                    resolve({
+                        success: false,
+                        output: `Agent killed by inactivity watchdog (no I/O for ${Math.round(watchdogMs / 1000)}s). Partial output:\n${output}`,
+                        error: "inactivity_timeout",
+                    });
+                }
+                else if (reason === "timeout") {
+                    logger.warn(`tmux session ${sessionName} timed out after ${Math.round(timeoutMs / 1000)}s`);
+                    resolve({
+                        success: false,
+                        output: `Agent timed out after ${Math.round(timeoutMs / 1000)}s. Partial output:\n${output}`,
+                        error: "timeout",
+                    });
+                }
+                else if (reason === "unexpected_exit") {
+                    logger.warn(`tmux session ${sessionName} exited without completion event`);
+                    resolve({
+                        success: false,
+                        output: `Agent session exited unexpectedly (no completion event received). Partial output:\n${output}`,
+                        error: "unexpected_exit",
+                    });
+                }
+                else {
+                    // Normal completion — only reached when completionEventReceived is true
+                    resolve({ success: true, output });
+                }
+            }
+            const rl = createInterface({ input: tail.stdout });
+            rl.on("line", (line) => {
+                if (!line.trim())
+                    return;
+                watchdog.tick();
+                let event;
+                try {
+                    event = JSON.parse(line);
+                }
+                catch {
+                    collectedMessages.push(line);
+                    return;
+                }
+                // Collect text for output — handle both Claude and Codex event shapes
+                if (event.type === "assistant") {
+                    // Claude stream-json shape
+                    const content = event.message?.content;
+                    if (Array.isArray(content)) {
+                        for (const block of content) {
+                            if (block.type === "text" && block.text) {
+                                collectedMessages.push(block.text);
+                            }
+                        }
+                    }
+                }
+                if (event.item?.type === "agent_message" || event.item?.type === "message") {
+                    // Codex --json shape
+                    const text = event.item.text ?? event.item.content ?? "";
+                    if (text)
+                        collectedMessages.push(text);
+                }
+                // Stream to Linear
+                const activities = mapEvent(event);
+                for (const activity of activities) {
+                    if (linearApi && agentSessionId) {
+                        linearApi.emitActivity(agentSessionId, activity).catch((err) => {
+                            logger.warn(`Failed to emit tmux activity: ${err}`);
+                        });
+                    }
+                    progress.push(formatActivityLogLine(activity));
+                }
+                // Detect completion across known CLI event shapes.
+                if (isCompletionEvent(event)) {
+                    completionEventReceived = true;
+                    cleanup("done");
+                    rl.close();
+                }
+            });
+            // Handle tail process ending (tmux session exited)
+            tail.on("close", () => {
+                if (!resolved) {
+                    // If we never saw a completion event, the session died unexpectedly
+                    if (completionEventReceived) {
+                        cleanup("done");
+                    }
+                    else {
+                        cleanup("unexpected_exit");
+                    }
+                }
+                rl.close();
+            });
+            tail.on("error", (err) => {
+                logger.error(`tmux tail error: ${err}`);
+                if (!resolved) {
+                    cleanup("error");
+                }
+                rl.close();
+            });
+        });
+    }
+    catch (err) {
+        // Clean up wrapper script on failure
+        try {
+            unlinkSync(scriptPath);
+        }
+        catch { /* best effort */ }
+        activeSessions.delete(issueId);
+        logger.error(`runInTmux failed: ${err}`);
+        return {
+            success: false,
+            output: `Failed to start tmux session: ${err}`,
+            error: String(err),
+        };
+    }
+}

--- a/dist/src/infra/tmux.js
+++ b/dist/src/infra/tmux.js
@@ -1,0 +1,39 @@
+import { execSync } from "node:child_process";
+/**
+ * Check if tmux is available on the system.
+ */
+export function isTmuxAvailable() {
+    try {
+        execSync("tmux -V", { stdio: "ignore" });
+        return true;
+    }
+    catch {
+        return false;
+    }
+}
+/**
+ * Build a deterministic tmux session name from issue identifier, backend, and index.
+ */
+export function buildSessionName(identifier, backend, index) {
+    // tmux session names can't contain dots or colons — sanitize
+    const safe = `${identifier}-${backend}-${index}`.replace(/[^a-zA-Z0-9_-]/g, "_");
+    return `claw-${safe}`;
+}
+/**
+ * Escape a string for safe shell interpolation (single-quote wrapping).
+ */
+export function shellEscape(value) {
+    // Wrap in single quotes, escaping any embedded single quotes
+    return `'${value.replace(/'/g, "'\\''")}'`;
+}
+/**
+ * Capture the last N lines from a tmux session pane.
+ */
+export function capturePane(sessionName, lines) {
+    try {
+        return execSync(`tmux capture-pane -t ${shellEscape(sessionName)} -p -S -${lines}`, { encoding: "utf8", timeout: 5_000 }).trimEnd();
+    }
+    catch {
+        return "";
+    }
+}

--- a/dist/src/infra/token-refresh-timer.js
+++ b/dist/src/infra/token-refresh-timer.js
@@ -1,0 +1,40 @@
+import { refreshTokenProactively } from "../api/linear-api.js";
+const REFRESH_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+let timer = null;
+/**
+ * Start the proactive token refresh timer.
+ * Runs immediately on start, then every 6 hours.
+ */
+export function startTokenRefreshTimer(api, pluginConfig) {
+    // Run immediately
+    doRefresh(api, pluginConfig);
+    // Then schedule periodic refresh
+    timer = setInterval(() => doRefresh(api, pluginConfig), REFRESH_INTERVAL_MS);
+    // Don't keep the process alive just for this timer
+    if (timer && typeof timer === "object" && "unref" in timer) {
+        timer.unref();
+    }
+}
+/**
+ * Stop the proactive token refresh timer.
+ */
+export function stopTokenRefreshTimer() {
+    if (timer) {
+        clearInterval(timer);
+        timer = null;
+    }
+}
+async function doRefresh(api, pluginConfig) {
+    try {
+        const result = await refreshTokenProactively(pluginConfig);
+        if (result.refreshed) {
+            api.logger.info(`Token refresh: ${result.reason}`);
+        }
+        else {
+            api.logger.debug?.(`Token refresh skipped: ${result.reason}`);
+        }
+    }
+    catch (err) {
+        api.logger.warn(`Token refresh failed: ${err}`);
+    }
+}

--- a/dist/src/infra/validation.js
+++ b/dist/src/infra/validation.js
@@ -1,0 +1,42 @@
+/**
+ * validation.ts — Shared validation utilities for Linear IDs and prompt text.
+ *
+ * Used by linear-issues-tool.ts to validate input before making API calls,
+ * and by pipeline components to sanitize text before embedding in prompts.
+ */
+// ---------------------------------------------------------------------------
+// UUID validation
+// ---------------------------------------------------------------------------
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export function isValidUuid(id) {
+    return UUID_REGEX.test(id);
+}
+// ---------------------------------------------------------------------------
+// Linear issue ID validation
+// ---------------------------------------------------------------------------
+/**
+ * Linear issue IDs are either short identifiers like "ENG-123" or UUIDs.
+ */
+const ISSUE_ID_REGEX = /^[A-Za-z][A-Za-z0-9]*-\d+$/;
+export function isValidIssueId(id) {
+    return ISSUE_ID_REGEX.test(id) || isValidUuid(id);
+}
+// ---------------------------------------------------------------------------
+// Team ID validation
+// ---------------------------------------------------------------------------
+export function isValidTeamId(id) {
+    return isValidUuid(id);
+}
+// ---------------------------------------------------------------------------
+// Prompt sanitization
+// ---------------------------------------------------------------------------
+/**
+ * Sanitize text before embedding in agent prompts.
+ * Truncates to prevent token budget abuse and escapes template patterns
+ * so user-supplied text cannot inject {{variable}} placeholders.
+ */
+export function sanitizeForPrompt(text, maxLength = 4000) {
+    return text
+        .replace(/\{\{.*?\}\}/g, "{ {escaped} }")
+        .slice(0, maxLength);
+}

--- a/dist/src/infra/webhook-provision.js
+++ b/dist/src/infra/webhook-provision.js
@@ -1,0 +1,96 @@
+// The exact set of resource types our webhook handler processes.
+export const REQUIRED_RESOURCE_TYPES = ["Comment", "Issue"];
+export const WEBHOOK_LABEL = "OpenClaw Integration";
+/**
+ * Inspect all webhooks and find the one(s) matching our URL pattern.
+ */
+export async function getWebhookStatus(linearApi, webhookUrl) {
+    const webhooks = await linearApi.listWebhooks();
+    const ours = webhooks.find((w) => w.url === webhookUrl);
+    if (!ours)
+        return null;
+    const issues = [];
+    if (!ours.enabled)
+        issues.push("disabled");
+    const currentTypes = new Set(ours.resourceTypes);
+    const requiredTypes = new Set(REQUIRED_RESOURCE_TYPES);
+    for (const t of requiredTypes) {
+        if (!currentTypes.has(t))
+            issues.push(`missing event type: ${t}`);
+    }
+    const noiseTypes = [...currentTypes].filter((t) => !requiredTypes.has(t));
+    if (noiseTypes.length > 0) {
+        issues.push(`unnecessary event types: ${noiseTypes.join(", ")}`);
+    }
+    return {
+        id: ours.id,
+        url: ours.url,
+        enabled: ours.enabled,
+        resourceTypes: ours.resourceTypes,
+        label: ours.label,
+        issues,
+    };
+}
+/**
+ * Provision (create or fix) the workspace webhook.
+ *
+ * - If no webhook with our URL exists → create one
+ * - If one exists but has wrong config → update it
+ * - If it's already correct → no-op
+ */
+export async function provisionWebhook(linearApi, webhookUrl, opts) {
+    const status = await getWebhookStatus(linearApi, webhookUrl);
+    if (!status) {
+        // No webhook found — create one
+        const result = await linearApi.createWebhook({
+            url: webhookUrl,
+            resourceTypes: [...REQUIRED_RESOURCE_TYPES],
+            label: WEBHOOK_LABEL,
+            enabled: true,
+            teamId: opts?.teamId,
+            allPublicTeams: opts?.allPublicTeams ?? true,
+        });
+        return {
+            action: "created",
+            webhookId: result.id,
+            changes: ["created new webhook"],
+        };
+    }
+    // Webhook exists — check if it needs updates
+    if (status.issues.length === 0) {
+        return { action: "already_ok", webhookId: status.id };
+    }
+    // Build update payload
+    const update = {};
+    const changes = [];
+    // Fix resource types
+    const currentTypes = new Set(status.resourceTypes);
+    const requiredTypes = new Set(REQUIRED_RESOURCE_TYPES);
+    const typesNeedUpdate = [...requiredTypes].some((t) => !currentTypes.has(t)) ||
+        [...currentTypes].some((t) => !requiredTypes.has(t));
+    if (typesNeedUpdate) {
+        update.resourceTypes = [...REQUIRED_RESOURCE_TYPES];
+        const removed = [...currentTypes].filter((t) => !requiredTypes.has(t));
+        const added = [...requiredTypes].filter((t) => !currentTypes.has(t));
+        if (removed.length)
+            changes.push(`removed event types: ${removed.join(", ")}`);
+        if (added.length)
+            changes.push(`added event types: ${added.join(", ")}`);
+    }
+    // Fix enabled state
+    if (!status.enabled) {
+        update.enabled = true;
+        changes.push("enabled webhook");
+    }
+    // Fix label if missing
+    if (!status.label) {
+        update.label = WEBHOOK_LABEL;
+        changes.push("set label");
+    }
+    await linearApi.updateWebhook(status.id, update);
+    return {
+        action: "updated",
+        webhookId: status.id,
+        changes,
+    };
+}

--- a/dist/src/pipeline/active-session.js
+++ b/dist/src/pipeline/active-session.js
@@ -1,0 +1,156 @@
+/**
+ * active-session.ts — Idempotent registry of active Linear agent sessions.
+ *
+ * When the pipeline starts work on an issue, it registers the session here.
+ * Any tool (cli_codex, cli_claude, etc.) can look up the active session for the current
+ * issue to stream activities without relying on the LLM agent to pass params.
+ *
+ * This runs in the gateway process. Tool execution also happens in the gateway,
+ * so tools can read from this registry directly.
+ *
+ * The in-memory Map is the fast-path for tool lookups. On startup, the
+ * dispatch service calls hydrateFromDispatchState() to rebuild it from
+ * the persistent dispatch-state.json file.
+ */
+import { readDispatchState } from "./dispatch-state.js";
+// Keyed by issue ID — one active session per issue at a time.
+const sessions = new Map();
+const issueAgentAffinity = new Map();
+let _affinityTtlMs = 30 * 60_000; // 30 minutes default
+/**
+ * Register the active session for an issue. Idempotent — calling again
+ * for the same issue just updates the session.
+ *
+ * Also eagerly records agent affinity so that follow-up webhooks arriving
+ * during or after the run resolve to the correct agent — even if the
+ * gateway restarts before clearActiveSession is called.
+ */
+export function setActiveSession(session) {
+    sessions.set(session.issueId, session);
+    if (session.agentId) {
+        recordIssueAffinity(session.issueId, session.agentId);
+    }
+}
+/**
+ * Clear the active session for an issue.
+ * If the session had an agentId, records it as affinity for future routing.
+ */
+export function clearActiveSession(issueId) {
+    const session = sessions.get(issueId);
+    if (session?.agentId) {
+        recordIssueAffinity(issueId, session.agentId);
+    }
+    sessions.delete(issueId);
+}
+/**
+ * Look up the active session for an issue by issue ID.
+ */
+export function getActiveSession(issueId) {
+    return sessions.get(issueId) ?? null;
+}
+/**
+ * Look up the active session by issue identifier (e.g. "API-472").
+ * Slower than by ID — scans all sessions.
+ */
+export function getActiveSessionByIdentifier(identifier) {
+    for (const session of sessions.values()) {
+        if (session.issueIdentifier === identifier)
+            return session;
+    }
+    return null;
+}
+/**
+ * Get the current active session. If there's exactly one, return it.
+ * If there are multiple (concurrent pipelines), returns null — caller
+ * must specify which issue.
+ */
+export function getCurrentSession() {
+    if (sessions.size === 1) {
+        return sessions.values().next().value ?? null;
+    }
+    return null;
+}
+/**
+ * Look up the most recent active session for a given agent ID.
+ * When multiple sessions exist for the same agent, returns the most
+ * recently started one. This is the primary lookup for tool execution
+ * contexts where the agent ID is known but the issue isn't.
+ */
+export function getActiveSessionByAgentId(agentId) {
+    let best = null;
+    for (const session of sessions.values()) {
+        if (session.agentId === agentId) {
+            if (!best || session.startedAt > best.startedAt) {
+                best = session;
+            }
+        }
+    }
+    return best;
+}
+/**
+ * Hydrate the in-memory session Map from dispatch-state.json.
+ * Called on startup by the dispatch service to restore sessions
+ * that were active before a gateway restart.
+ *
+ * Returns the number of sessions restored.
+ */
+export async function hydrateFromDispatchState(configPath) {
+    const state = await readDispatchState(configPath);
+    const active = state.dispatches.active;
+    let restored = 0;
+    for (const [, dispatch] of Object.entries(active)) {
+        if (dispatch.status === "dispatched" || dispatch.status === "working") {
+            sessions.set(dispatch.issueId, {
+                agentSessionId: dispatch.agentSessionId ?? "",
+                issueIdentifier: dispatch.issueIdentifier,
+                issueId: dispatch.issueId,
+                startedAt: new Date(dispatch.dispatchedAt).getTime(),
+            });
+            restored++;
+        }
+    }
+    return restored;
+}
+/**
+ * Get the count of currently tracked sessions.
+ */
+export function getSessionCount() {
+    return sessions.size;
+}
+// ---------------------------------------------------------------------------
+// Issue-agent affinity — public API
+// ---------------------------------------------------------------------------
+/**
+ * Record which agent last handled an issue.
+ * Called automatically from clearActiveSession when an agentId is present.
+ */
+export function recordIssueAffinity(issueId, agentId) {
+    issueAgentAffinity.set(issueId, { agentId, recordedAt: Date.now() });
+}
+/**
+ * Look up which agent last handled an issue.
+ * Returns null if no affinity recorded or if the entry has expired.
+ */
+export function getIssueAffinity(issueId) {
+    const entry = issueAgentAffinity.get(issueId);
+    if (!entry)
+        return null;
+    if (Date.now() - entry.recordedAt > _affinityTtlMs) {
+        issueAgentAffinity.delete(issueId);
+        return null;
+    }
+    return entry.agentId;
+}
+/** @internal — configure affinity TTL from pluginConfig. */
+export function _configureAffinityTtl(ttlMs) {
+    _affinityTtlMs = ttlMs ?? 30 * 60_000;
+}
+/** @internal — read current affinity TTL (for testing). */
+export function _getAffinityTtlMs() {
+    return _affinityTtlMs;
+}
+/** @internal — test-only; clears all affinity state and resets TTL. */
+export function _resetAffinityForTesting() {
+    issueAgentAffinity.clear();
+    _affinityTtlMs = 30 * 60_000;
+}

--- a/dist/src/pipeline/artifacts.js
+++ b/dist/src/pipeline/artifacts.js
@@ -1,0 +1,264 @@
+/**
+ * artifacts.ts — .claw/ per-worktree artifact convention.
+ *
+ * Provides a standard directory structure for storing artifacts during
+ * the lifecycle of a dispatched issue. Any OpenClaw plugin that works
+ * with a worktree can write to {worktreePath}/.claw/.
+ *
+ * Structure:
+ *   .claw/
+ *     manifest.json     — issue metadata + lifecycle timestamps
+ *     plan.md           — implementation plan
+ *     worker-{N}.md     — worker output per attempt (truncated)
+ *     audit-{N}.json    — audit verdict per attempt
+ *     log.jsonl         — append-only interaction log
+ *     summary.md        — agent-curated final summary
+ */
+import { existsSync, mkdirSync, readFileSync, appendFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+const MAX_ARTIFACT_SIZE = 8192; // 8KB per output file
+const MAX_PREVIEW_SIZE = 500; // For log entry previews
+const MAX_PROMPT_PREVIEW = 200; // For log entry prompt previews
+// ---------------------------------------------------------------------------
+// Directory setup
+// ---------------------------------------------------------------------------
+function clawDir(worktreePath) {
+    return join(worktreePath, ".claw");
+}
+/** Creates .claw/ directory. Returns the path. */
+export function ensureClawDir(worktreePath) {
+    const dir = clawDir(worktreePath);
+    if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+    }
+    return dir;
+}
+/**
+ * Ensure .claw/ is in .gitignore at the worktree root.
+ * Appends if not already present. Idempotent.
+ */
+export function ensureGitignore(worktreePath) {
+    const gitignorePath = join(worktreePath, ".gitignore");
+    try {
+        const content = existsSync(gitignorePath)
+            ? readFileSync(gitignorePath, "utf-8")
+            : "";
+        if (!content.split("\n").some((line) => line.trim() === ".claw" || line.trim() === ".claw/")) {
+            const nl = content.length > 0 && !content.endsWith("\n") ? "\n" : "";
+            appendFileSync(gitignorePath, `${nl}.claw/\n`, "utf-8");
+        }
+    }
+    catch {
+        // Best effort — don't block pipeline
+    }
+}
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+export function writeManifest(worktreePath, manifest) {
+    const dir = ensureClawDir(worktreePath);
+    writeFileSync(join(dir, "manifest.json"), JSON.stringify(manifest, null, 2) + "\n", "utf-8");
+}
+export function readManifest(worktreePath) {
+    try {
+        const raw = readFileSync(join(clawDir(worktreePath), "manifest.json"), "utf-8");
+        return JSON.parse(raw);
+    }
+    catch {
+        return null;
+    }
+}
+export function updateManifest(worktreePath, updates) {
+    const current = readManifest(worktreePath);
+    if (!current)
+        return;
+    writeManifest(worktreePath, { ...current, ...updates });
+}
+// ---------------------------------------------------------------------------
+// Phase artifacts
+// ---------------------------------------------------------------------------
+/** Save worker output for a given attempt. Truncated to MAX_ARTIFACT_SIZE. */
+export function saveWorkerOutput(worktreePath, attempt, output) {
+    const dir = ensureClawDir(worktreePath);
+    const truncated = output.length > MAX_ARTIFACT_SIZE
+        ? output.slice(0, MAX_ARTIFACT_SIZE) + "\n\n--- truncated ---"
+        : output;
+    writeFileSync(join(dir, `worker-${attempt}.md`), truncated, "utf-8");
+}
+/** Save a plan (extracted from worker output or provided directly). */
+export function savePlan(worktreePath, plan) {
+    const dir = ensureClawDir(worktreePath);
+    writeFileSync(join(dir, "plan.md"), plan, "utf-8");
+}
+/** Save audit verdict for a given attempt. */
+export function saveAuditVerdict(worktreePath, attempt, verdict) {
+    const dir = ensureClawDir(worktreePath);
+    writeFileSync(join(dir, `audit-${attempt}.json`), JSON.stringify(verdict, null, 2) + "\n", "utf-8");
+}
+// ---------------------------------------------------------------------------
+// Interaction log
+// ---------------------------------------------------------------------------
+/** Append a structured log entry to .claw/log.jsonl. */
+export function appendLog(worktreePath, entry) {
+    const dir = ensureClawDir(worktreePath);
+    const truncated = {
+        ...entry,
+        prompt: entry.prompt.slice(0, MAX_PROMPT_PREVIEW),
+        outputPreview: entry.outputPreview.slice(0, MAX_PREVIEW_SIZE),
+    };
+    appendFileSync(join(dir, "log.jsonl"), JSON.stringify(truncated) + "\n", "utf-8");
+}
+// ---------------------------------------------------------------------------
+// Summary
+// ---------------------------------------------------------------------------
+/** Write the final curated summary. */
+export function writeSummary(worktreePath, summary) {
+    const dir = ensureClawDir(worktreePath);
+    writeFileSync(join(dir, "summary.md"), summary, "utf-8");
+}
+/**
+ * Build a markdown summary from all .claw/ artifacts.
+ * Used at issue completion to generate a memory-friendly summary.
+ */
+export function buildSummaryFromArtifacts(worktreePath) {
+    const manifest = readManifest(worktreePath);
+    if (!manifest)
+        return null;
+    const parts = [];
+    parts.push(`# Dispatch: ${manifest.issueIdentifier} — ${manifest.issueTitle}`);
+    parts.push(`**Tier:** ${manifest.tier} | **Status:** ${manifest.status} | **Attempts:** ${manifest.attempts}`);
+    parts.push("");
+    // Include plan if exists
+    try {
+        const plan = readFileSync(join(clawDir(worktreePath), "plan.md"), "utf-8");
+        parts.push("## Plan");
+        parts.push(plan.slice(0, 2000));
+        parts.push("");
+    }
+    catch { /* no plan */ }
+    // Include each attempt's worker + audit
+    for (let i = 0; i < manifest.attempts; i++) {
+        parts.push(`## Attempt ${i}`);
+        // Worker output preview
+        try {
+            const worker = readFileSync(join(clawDir(worktreePath), `worker-${i}.md`), "utf-8");
+            parts.push("### Worker Output");
+            parts.push(worker.slice(0, 1500));
+            parts.push("");
+        }
+        catch { /* no worker output */ }
+        // Audit verdict
+        try {
+            const raw = readFileSync(join(clawDir(worktreePath), `audit-${i}.json`), "utf-8");
+            const verdict = JSON.parse(raw);
+            parts.push(`### Audit: ${verdict.pass ? "PASS" : "FAIL"}`);
+            if (verdict.criteria.length)
+                parts.push(`**Criteria:** ${verdict.criteria.join(", ")}`);
+            if (verdict.gaps.length)
+                parts.push(`**Gaps:** ${verdict.gaps.join(", ")}`);
+            if (verdict.testResults)
+                parts.push(`**Tests:** ${verdict.testResults}`);
+            parts.push("");
+        }
+        catch { /* no audit */ }
+    }
+    parts.push("---");
+    parts.push(`*Artifacts: ${worktreePath}/.claw/*`);
+    return parts.join("\n");
+}
+/**
+ * Write dispatch summary to the orchestrator's memory directory
+ * with YAML frontmatter for searchable metadata.
+ * Auto-indexed by OpenClaw's sqlite+embeddings memory system.
+ */
+export function writeDispatchMemory(issueIdentifier, summary, workspaceDir, metadata) {
+    const memDir = join(workspaceDir, "memory");
+    if (!existsSync(memDir)) {
+        mkdirSync(memDir, { recursive: true });
+    }
+    const fm = {
+        type: "dispatch",
+        issue: issueIdentifier,
+        title: metadata?.title ?? issueIdentifier,
+        tier: metadata?.tier ?? "unknown",
+        status: metadata?.status ?? "unknown",
+        project: metadata?.project,
+        attempts: metadata?.attempts ?? 0,
+        model: metadata?.model ?? "unknown",
+        date: metadata?.date ?? new Date().toISOString().slice(0, 10),
+    };
+    const frontmatter = [
+        "---",
+        ...Object.entries(fm)
+            .filter(([, v]) => v !== undefined)
+            .map(([k, v]) => `${k}: ${typeof v === "string" ? `"${v}"` : v}`),
+        "---",
+        "",
+    ].join("\n");
+    writeFileSync(join(memDir, `dispatch-${issueIdentifier}.md`), frontmatter + summary, "utf-8");
+}
+/**
+ * Resolve the orchestrator agent's workspace directory from config.
+ * Same config-based approach as resolveAgentDirs in agent.ts.
+ */
+export function resolveOrchestratorWorkspace(api, pluginConfig) {
+    const home = homedir();
+    const agentId = pluginConfig?.defaultAgentId ?? "default";
+    try {
+        const config = api.runtime.config.loadConfig();
+        const agentList = config?.agents?.list;
+        const agentEntry = agentList?.find((a) => a.id === agentId);
+        return agentEntry?.workspace
+            ?? config?.agents?.defaults?.workspace
+            ?? join(home, ".openclaw", "workspace");
+    }
+    catch {
+        return join(home, ".openclaw", "workspace");
+    }
+}
+/**
+ * Read worker output artifacts for all attempts.
+ */
+export function readWorkerOutputs(worktreePath, maxAttempt) {
+    const outputs = [];
+    for (let i = 0; i <= maxAttempt; i++) {
+        try {
+            outputs.push(readFileSync(join(clawDir(worktreePath), `worker-${i}.md`), "utf-8"));
+        }
+        catch {
+            outputs.push("(not found)");
+        }
+    }
+    return outputs;
+}
+/**
+ * Read audit verdict artifacts for all attempts.
+ */
+export function readAuditVerdicts(worktreePath, maxAttempt) {
+    const verdicts = [];
+    for (let i = 0; i <= maxAttempt; i++) {
+        try {
+            verdicts.push(readFileSync(join(clawDir(worktreePath), `audit-${i}.json`), "utf-8"));
+        }
+        catch {
+            verdicts.push("(not found)");
+        }
+    }
+    return verdicts;
+}
+/**
+ * Read the interaction log entries.
+ */
+export function readLog(worktreePath) {
+    try {
+        const raw = readFileSync(join(clawDir(worktreePath), "log.jsonl"), "utf-8");
+        return raw.trim().split("\n").filter(Boolean);
+    }
+    catch {
+        return [];
+    }
+}

--- a/dist/src/pipeline/dag-dispatch.js
+++ b/dist/src/pipeline/dag-dispatch.js
@@ -1,0 +1,274 @@
+import { readPlanningState, writePlanningState } from "./planning-state.js";
+/**
+ * Build a dispatch queue from the project's issue DAG.
+ * Parses blocks/blocked_by relations and returns a map of issue statuses.
+ * Epics are skipped (marked as "skipped") since they're organizational only.
+ */
+export function buildDispatchQueue(issues) {
+    const queue = {};
+    const identifiers = new Set(issues.map((i) => i.identifier));
+    // Initialize all issues
+    for (const issue of issues) {
+        const isEpic = issue.labels?.nodes?.some((l) => l.name.toLowerCase().includes("epic"));
+        queue[issue.identifier] = {
+            identifier: issue.identifier,
+            issueId: issue.id,
+            dependsOn: [],
+            unblocks: [],
+            dispatchStatus: isEpic ? "skipped" : "pending",
+        };
+    }
+    // Parse relations
+    for (const issue of issues) {
+        const entry = queue[issue.identifier];
+        if (!entry)
+            continue;
+        for (const rel of issue.relations?.nodes ?? []) {
+            const target = rel.relatedIssue?.identifier;
+            if (!target || !identifiers.has(target))
+                continue;
+            if (rel.type === "blocks") {
+                // This issue blocks target → target depends on this
+                entry.unblocks.push(target);
+                const targetEntry = queue[target];
+                if (targetEntry)
+                    targetEntry.dependsOn.push(issue.identifier);
+            }
+            else if (rel.type === "blocked_by") {
+                // This issue is blocked by target → this depends on target
+                entry.dependsOn.push(target);
+                const targetEntry = queue[target];
+                if (targetEntry)
+                    targetEntry.unblocks.push(issue.identifier);
+            }
+        }
+    }
+    // Filter out skipped issues from dependency lists
+    for (const entry of Object.values(queue)) {
+        entry.dependsOn = entry.dependsOn.filter((id) => queue[id]?.dispatchStatus !== "skipped");
+        entry.unblocks = entry.unblocks.filter((id) => queue[id]?.dispatchStatus !== "skipped");
+    }
+    return queue;
+}
+// ---------------------------------------------------------------------------
+// Ready issue detection
+// ---------------------------------------------------------------------------
+/**
+ * Return issues that are ready to dispatch: all dependencies are done
+ * and the issue is still pending.
+ */
+export function getReadyIssues(issues) {
+    return Object.values(issues).filter((issue) => {
+        if (issue.dispatchStatus !== "pending")
+            return false;
+        return issue.dependsOn.every((dep) => issues[dep]?.dispatchStatus === "done");
+    });
+}
+/**
+ * Count how many issues are currently in-flight (dispatched but not done/stuck).
+ */
+export function getActiveCount(issues) {
+    return Object.values(issues).filter((i) => i.dispatchStatus === "dispatched").length;
+}
+/**
+ * Check if all dispatchable issues are terminal (done, stuck, or skipped).
+ */
+export function isProjectDispatchComplete(issues) {
+    return Object.values(issues).every((i) => i.dispatchStatus === "done" || i.dispatchStatus === "stuck" || i.dispatchStatus === "skipped");
+}
+/**
+ * Check if the project is stuck: at least one issue stuck, and no more
+ * issues can make progress (everything pending depends on stuck issues).
+ */
+export function isProjectStuck(issues) {
+    const hasStuck = Object.values(issues).some((i) => i.dispatchStatus === "stuck");
+    if (!hasStuck)
+        return false;
+    // Check if any pending issue could still become ready
+    const readyCount = getReadyIssues(issues).length;
+    const activeCount = getActiveCount(issues);
+    return readyCount === 0 && activeCount === 0;
+}
+// ---------------------------------------------------------------------------
+// State persistence (extends planning-state.json)
+// ---------------------------------------------------------------------------
+export async function readProjectDispatch(projectId, configPath) {
+    const state = await readPlanningState(configPath);
+    const dispatches = state.projectDispatches;
+    return dispatches?.[projectId] ?? null;
+}
+export async function writeProjectDispatch(projectDispatch, configPath) {
+    const state = await readPlanningState(configPath);
+    if (!state.projectDispatches) {
+        state.projectDispatches = {};
+    }
+    state.projectDispatches[projectDispatch.projectId] = projectDispatch;
+    await writePlanningState(state, configPath);
+}
+// ---------------------------------------------------------------------------
+// Dispatch orchestration
+// ---------------------------------------------------------------------------
+/**
+ * Start dispatching a project's issues in topological order.
+ * Called after plan approval.
+ */
+export async function startProjectDispatch(hookCtx, projectId, opts) {
+    const { api, linearApi, notify, pluginConfig, configPath } = hookCtx;
+    const maxConcurrent = opts?.maxConcurrent
+        ?? pluginConfig?.maxConcurrentDispatches
+        ?? 3;
+    // Fetch project metadata
+    const project = await linearApi.getProject(projectId);
+    const issues = await linearApi.getProjectIssues(projectId);
+    if (issues.length === 0) {
+        api.logger.warn(`DAG dispatch: no issues found for project ${projectId}`);
+        return;
+    }
+    // Build dispatch queue
+    const queue = buildDispatchQueue(issues);
+    const dispatchableCount = Object.values(queue).filter((i) => i.dispatchStatus === "pending").length;
+    // Find root identifier (from planning session)
+    const planState = await readPlanningState(configPath);
+    const session = planState.sessions[projectId];
+    const rootIdentifier = session?.rootIdentifier ?? project.name;
+    const projectDispatch = {
+        projectId,
+        projectName: project.name,
+        rootIdentifier,
+        status: "dispatching",
+        startedAt: new Date().toISOString(),
+        maxConcurrent,
+        issues: queue,
+    };
+    await writeProjectDispatch(projectDispatch, configPath);
+    api.logger.info(`DAG dispatch: started for ${project.name} — ${dispatchableCount} dispatchable issues, ` +
+        `max concurrent: ${maxConcurrent}`);
+    await notify("project_progress", {
+        identifier: rootIdentifier,
+        title: project.name,
+        status: `dispatching (0/${dispatchableCount} complete)`,
+    });
+    // Dispatch initial leaf issues
+    await dispatchReadyIssues(hookCtx, projectDispatch);
+}
+/**
+ * Dispatch all ready issues up to the concurrency limit.
+ * Called on start and after each issue completes.
+ */
+export async function dispatchReadyIssues(hookCtx, projectDispatch) {
+    const { api, linearApi, pluginConfig, configPath } = hookCtx;
+    const ready = getReadyIssues(projectDispatch.issues);
+    const active = getActiveCount(projectDispatch.issues);
+    const slots = projectDispatch.maxConcurrent - active;
+    if (ready.length === 0 || slots <= 0)
+        return;
+    const toDispatch = ready.slice(0, slots);
+    for (const issue of toDispatch) {
+        issue.dispatchStatus = "dispatched";
+        api.logger.info(`DAG dispatch: dispatching ${issue.identifier}`);
+    }
+    // Persist state before dispatching (so crashes don't re-dispatch)
+    await writeProjectDispatch(projectDispatch, configPath);
+    // Trigger handleDispatch for each issue via webhook.ts's existing mechanism.
+    // We assign the issue to the bot, which triggers the normal dispatch flow.
+    const agentId = pluginConfig?.defaultAgentId ?? "default";
+    for (const issue of toDispatch) {
+        try {
+            // Use updateIssueExtended to assign the issue (triggers Issue.update webhook)
+            // But that would create a circular dispatch. Instead, we directly import
+            // and call the pipeline's spawnWorker with a freshly registered dispatch.
+            //
+            // For now, emit a dispatch event that the existing pipeline picks up.
+            // The simplest approach: use linearApi to assign the issue to the bot user,
+            // which triggers the normal webhook → handleDispatch flow.
+            //
+            // However, this is better handled by directly invoking the dispatch logic.
+            // We'll emit a log and let the dispatch-service pick these up on its next tick.
+            api.logger.info(`DAG dispatch: ${issue.identifier} is ready for dispatch ` +
+                `(deps satisfied: ${issue.dependsOn.join(", ") || "none"})`);
+        }
+        catch (err) {
+            api.logger.error(`DAG dispatch: failed to dispatch ${issue.identifier}: ${err}`);
+        }
+    }
+}
+/**
+ * Called when a dispatch completes (audit passed → done).
+ * Marks the issue as done, checks for newly unblocked issues, dispatches them.
+ */
+export async function onProjectIssueCompleted(hookCtx, projectId, identifier) {
+    const { api, notify, configPath } = hookCtx;
+    const projectDispatch = await readProjectDispatch(projectId, configPath);
+    if (!projectDispatch || projectDispatch.status !== "dispatching")
+        return;
+    const issue = projectDispatch.issues[identifier];
+    if (!issue) {
+        api.logger.warn(`DAG dispatch: ${identifier} not found in project dispatch for ${projectId}`);
+        return;
+    }
+    // Mark as done
+    issue.dispatchStatus = "done";
+    issue.completedAt = new Date().toISOString();
+    // Count progress
+    const total = Object.values(projectDispatch.issues).filter((i) => i.dispatchStatus !== "skipped").length;
+    const done = Object.values(projectDispatch.issues).filter((i) => i.dispatchStatus === "done").length;
+    api.logger.info(`DAG dispatch: ${identifier} completed (${done}/${total})`);
+    // Check if project is complete
+    if (isProjectDispatchComplete(projectDispatch.issues)) {
+        projectDispatch.status = "completed";
+        await writeProjectDispatch(projectDispatch, configPath);
+        api.logger.info(`DAG dispatch: project ${projectDispatch.projectName} COMPLETE (${done}/${total})`);
+        await notify("project_complete", {
+            identifier: projectDispatch.rootIdentifier,
+            title: projectDispatch.projectName,
+            status: `complete (${done}/${total} issues)`,
+        });
+        return;
+    }
+    // Check if stuck (no progress possible)
+    if (isProjectStuck(projectDispatch.issues)) {
+        projectDispatch.status = "stuck";
+        await writeProjectDispatch(projectDispatch, configPath);
+        const stuckIssues = Object.values(projectDispatch.issues)
+            .filter((i) => i.dispatchStatus === "stuck")
+            .map((i) => i.identifier);
+        api.logger.warn(`DAG dispatch: project ${projectDispatch.projectName} STUCK ` +
+            `(blocked by: ${stuckIssues.join(", ")})`);
+        await notify("project_progress", {
+            identifier: projectDispatch.rootIdentifier,
+            title: projectDispatch.projectName,
+            status: `stuck (${done}/${total} complete, blocked by ${stuckIssues.join(", ")})`,
+            reason: `blocked by stuck issues: ${stuckIssues.join(", ")}`,
+        });
+        return;
+    }
+    // Save and dispatch newly ready issues
+    await writeProjectDispatch(projectDispatch, configPath);
+    await notify("project_progress", {
+        identifier: projectDispatch.rootIdentifier,
+        title: projectDispatch.projectName,
+        status: `${done}/${total} complete`,
+    });
+    await dispatchReadyIssues(hookCtx, projectDispatch);
+}
+/**
+ * Called when a dispatch gets stuck (audit failed too many times).
+ * Marks the issue as stuck in the project dispatch state.
+ */
+export async function onProjectIssueStuck(hookCtx, projectId, identifier) {
+    const { api, configPath } = hookCtx;
+    const projectDispatch = await readProjectDispatch(projectId, configPath);
+    if (!projectDispatch || projectDispatch.status !== "dispatching")
+        return;
+    const issue = projectDispatch.issues[identifier];
+    if (!issue)
+        return;
+    issue.dispatchStatus = "stuck";
+    await writeProjectDispatch(projectDispatch, configPath);
+    api.logger.info(`DAG dispatch: ${identifier} stuck in project ${projectDispatch.projectName}`);
+    // Check if the entire project is now stuck
+    if (isProjectStuck(projectDispatch.issues)) {
+        projectDispatch.status = "stuck";
+        await writeProjectDispatch(projectDispatch, configPath);
+    }
+}

--- a/dist/src/pipeline/dispatch-service.js
+++ b/dist/src/pipeline/dispatch-service.js
@@ -1,0 +1,162 @@
+/**
+ * dispatch-service.ts — Background service for dispatch health monitoring.
+ *
+ * Registered via api.registerService(). Runs on a 5-minute interval.
+ * Zero LLM tokens — all logic is deterministic code.
+ *
+ * Responsibilities:
+ * - Hydrate active sessions from dispatch-state.json on startup
+ * - Detect stale dispatches (active >2h with no progress)
+ * - Verify worktree health for active dispatches
+ * - Prune completed dispatches older than 7 days
+ */
+import { existsSync } from "node:fs";
+import { hydrateFromDispatchState } from "./active-session.js";
+import { readDispatchState, listStaleDispatches, listRecoverableDispatches, transitionDispatch, TransitionError, pruneCompleted, } from "./dispatch-state.js";
+import { getWorktreeStatus } from "../infra/codex-worktree.js";
+import { emitDiagnostic } from "../infra/observability.js";
+const INTERVAL_MS = 5 * 60_000; // 5 minutes
+const STALE_THRESHOLD_MS = 2 * 60 * 60_000; // 2 hours
+const COMPLETED_MAX_AGE_MS = 7 * 24 * 60 * 60_000; // 7 days
+const ZOMBIE_THRESHOLD_MS = 30 * 60_000; // 30 min — session dead but status active
+export function createDispatchService(api) {
+    let intervalId = null;
+    const pluginConfig = api.pluginConfig;
+    const statePath = pluginConfig?.dispatchStatePath;
+    return {
+        id: "linear-dispatch-monitor",
+        start: async (ctx) => {
+            // Hydrate active sessions on startup
+            try {
+                const restored = await hydrateFromDispatchState(statePath);
+                if (restored > 0) {
+                    ctx.logger.info(`linear-dispatch: hydrated ${restored} active session(s) from dispatch state`);
+                }
+            }
+            catch (err) {
+                ctx.logger.warn(`linear-dispatch: hydration failed: ${err}`);
+            }
+            // Recovery scan: find dispatches stuck in "working" with a workerSessionKey
+            // but no auditSessionKey (worker completed but audit wasn't triggered before crash)
+            try {
+                const state = await readDispatchState(statePath);
+                const recoverable = listRecoverableDispatches(state);
+                for (const d of recoverable) {
+                    ctx.logger.warn(`linear-dispatch: recoverable dispatch ${d.issueIdentifier} ` +
+                        `(status: ${d.status}, attempt: ${d.attempt}, workerKey: ${d.workerSessionKey}, auditKey: ${d.auditSessionKey ?? "none"})`);
+                    // Mark as stuck for manual review — automated recovery requires
+                    // re-triggering audit which needs the full HookContext (Linear API, notifier).
+                    // The dispatch monitor logs a warning; operator can re-dispatch.
+                }
+                if (recoverable.length > 0) {
+                    ctx.logger.warn(`linear-dispatch: ${recoverable.length} dispatch(es) need recovery — consider re-dispatching`);
+                }
+            }
+            catch (err) {
+                ctx.logger.warn(`linear-dispatch: recovery scan failed: ${err}`);
+            }
+            ctx.logger.info(`linear-dispatch: service started (interval: ${INTERVAL_MS / 1000}s)`);
+            intervalId = setInterval(() => runTick(ctx), INTERVAL_MS);
+        },
+        stop: async (ctx) => {
+            if (intervalId) {
+                clearInterval(intervalId);
+                intervalId = null;
+                ctx.logger.info("linear-dispatch: service stopped");
+            }
+        },
+    };
+    async function runTick(ctx) {
+        try {
+            const state = await readDispatchState(statePath);
+            const activeCount = Object.keys(state.dispatches.active).length;
+            // Skip tick if nothing to do
+            if (activeCount === 0 && Object.keys(state.dispatches.completed).length === 0)
+                return;
+            // 1. Stale dispatch detection — transition truly stale dispatches to "stuck"
+            const stale = listStaleDispatches(state, STALE_THRESHOLD_MS);
+            for (const dispatch of stale) {
+                // Skip terminal states
+                if (dispatch.status === "done" || dispatch.status === "failed" || dispatch.status === "stuck") {
+                    continue;
+                }
+                // Check if worktree still exists and has progress
+                if (existsSync(dispatch.worktreePath)) {
+                    const status = getWorktreeStatus(dispatch.worktreePath);
+                    if (status.hasUncommitted || status.lastCommit) {
+                        // Worktree has activity — not truly stale, just slow
+                        continue;
+                    }
+                }
+                ctx.logger.warn(`linear-dispatch: stale dispatch ${dispatch.issueIdentifier} ` +
+                    `(dispatched ${dispatch.dispatchedAt}, status: ${dispatch.status}) — transitioning to stuck`);
+                // Try to transition to stuck
+                try {
+                    await transitionDispatch(dispatch.issueIdentifier, dispatch.status, "stuck", { stuckReason: `stale_${Math.round((Date.now() - new Date(dispatch.dispatchedAt).getTime()) / 3_600_000)}h` }, statePath);
+                    ctx.logger.info(`linear-dispatch: ${dispatch.issueIdentifier} marked as stuck`);
+                }
+                catch (err) {
+                    if (err instanceof TransitionError) {
+                        ctx.logger.info(`linear-dispatch: CAS failed for stale transition: ${err.message}`);
+                    }
+                    else {
+                        ctx.logger.error(`linear-dispatch: stale transition error: ${err}`);
+                    }
+                }
+            }
+            // 2. Health check triangulation — cross-reference dispatch state, worktree,
+            //    and session mapping to detect zombie dispatches
+            for (const [id, dispatch] of Object.entries(state.dispatches.active)) {
+                // Worktree existence check
+                if (!existsSync(dispatch.worktreePath)) {
+                    ctx.logger.warn(`linear-dispatch: worktree missing for ${id} at ${dispatch.worktreePath}`);
+                }
+                // Zombie detection: dispatch says "working" or "auditing" but has been
+                // in that state for >30 min with no session mapping (session died mid-flight)
+                if ((dispatch.status === "working" || dispatch.status === "auditing") &&
+                    !stale.includes(dispatch) // not already caught by stale detection
+                ) {
+                    const dispatchAge = Date.now() - new Date(dispatch.dispatchedAt).getTime();
+                    const hasSessionKey = dispatch.status === "working"
+                        ? !!dispatch.workerSessionKey
+                        : !!dispatch.auditSessionKey;
+                    const sessionKeyInMap = hasSessionKey && (dispatch.status === "working"
+                        ? !!state.sessionMap[dispatch.workerSessionKey]
+                        : !!state.sessionMap[dispatch.auditSessionKey]);
+                    // If dispatch is active but session mapping is gone → zombie
+                    if (dispatchAge > ZOMBIE_THRESHOLD_MS && hasSessionKey && !sessionKeyInMap) {
+                        ctx.logger.warn(`linear-dispatch: zombie detected ${id} — ${dispatch.status} for ` +
+                            `${Math.round(dispatchAge / 60_000)}m but session mapping missing`);
+                        emitDiagnostic(api, {
+                            event: "health_check",
+                            identifier: id,
+                            phase: dispatch.status,
+                            error: "zombie_session",
+                        });
+                        // Transition to stuck
+                        try {
+                            await transitionDispatch(id, dispatch.status, "stuck", { stuckReason: "zombie_session" }, statePath);
+                            ctx.logger.info(`linear-dispatch: ${id} → stuck (zombie)`);
+                        }
+                        catch (err) {
+                            if (err instanceof TransitionError) {
+                                ctx.logger.info(`linear-dispatch: CAS failed for zombie transition: ${err.message}`);
+                            }
+                        }
+                    }
+                }
+            }
+            // 3. Prune old completed entries
+            const pruned = await pruneCompleted(COMPLETED_MAX_AGE_MS, statePath);
+            if (pruned > 0) {
+                ctx.logger.info(`linear-dispatch: pruned ${pruned} old completed dispatch(es)`);
+            }
+            if (activeCount > 0) {
+                ctx.logger.info(`linear-dispatch: tick — ${activeCount} active, ${stale.length} stale`);
+            }
+        }
+        catch (err) {
+            ctx.logger.error(`linear-dispatch: tick failed: ${err}`);
+        }
+    }
+}

--- a/dist/src/pipeline/dispatch-state.js
+++ b/dist/src/pipeline/dispatch-state.js
@@ -1,0 +1,396 @@
+/**
+ * dispatch-state.ts — File-backed persistent dispatch state (v2).
+ *
+ * Tracks active and completed dispatches across gateway restarts.
+ * Uses file-level locking to prevent concurrent read-modify-write races.
+ *
+ * v2 additions:
+ * - Atomic compare-and-swap (CAS) transitions
+ * - Session-to-dispatch map for agent_end hook lookup
+ * - Monotonic attempt counter for stale-event rejection
+ * - "stuck" as terminal state with reason
+ * - No separate "rework" state — rework is "working" with attempt > 0
+ */
+import fs from "node:fs/promises";
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+/** Valid CAS transitions: from → allowed next states */
+const VALID_TRANSITIONS = {
+    dispatched: ["working", "failed", "stuck"],
+    working: ["auditing", "failed", "stuck"],
+    auditing: ["done", "working", "stuck"], // working = rework (attempt++)
+    done: [], // terminal
+    failed: [], // terminal
+    stuck: [], // terminal
+};
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+const DEFAULT_STATE_PATH = path.join(homedir(), ".openclaw", "linear-dispatch-state.json");
+const MAX_PROCESSED_EVENTS = 200; // Keep last N events for dedup
+function resolveStatePath(configPath) {
+    if (!configPath)
+        return DEFAULT_STATE_PATH;
+    if (configPath.startsWith("~/"))
+        return configPath.replace("~", homedir());
+    return configPath;
+}
+// ---------------------------------------------------------------------------
+// File locking (shared utility)
+// ---------------------------------------------------------------------------
+import { acquireLock, releaseLock } from "../infra/file-lock.js";
+// ---------------------------------------------------------------------------
+// Read / Write
+// ---------------------------------------------------------------------------
+function emptyState() {
+    return {
+        version: 2,
+        dispatches: { active: {}, completed: {} },
+        sessionMap: {},
+        processedEvents: [],
+    };
+}
+/** Migrate state from any known version to the current version (2). */
+function migrateState(raw) {
+    const version = raw?.version ?? 1;
+    switch (version) {
+        case 1: {
+            // v1 → v2: add sessionMap, processedEvents, attempt defaults, status rename
+            const state = raw;
+            if (!state.sessionMap)
+                state.sessionMap = {};
+            if (!state.processedEvents)
+                state.processedEvents = [];
+            // Ensure all active dispatches have attempt field
+            for (const d of Object.values(state.dispatches.active)) {
+                if (d.attempt === undefined)
+                    d.attempt = 0;
+            }
+            // Migrate old status "running" → "working"
+            for (const d of Object.values(state.dispatches.active)) {
+                if (d.status === "running")
+                    d.status = "working";
+            }
+            state.version = 2;
+            return state;
+        }
+        case 2:
+            return raw;
+        default:
+            throw new Error(`Unknown dispatch state version: ${version}`);
+    }
+}
+export async function readDispatchState(configPath) {
+    const filePath = resolveStatePath(configPath);
+    try {
+        const raw = await fs.readFile(filePath, "utf-8");
+        return migrateState(JSON.parse(raw));
+    }
+    catch (err) {
+        if (err.code === "ENOENT")
+            return emptyState();
+        if (err instanceof SyntaxError) {
+            // State file corrupted — log and recover
+            console.error(`Dispatch state corrupted at ${filePath}: ${err.message}. Starting fresh.`);
+            // Rename corrupted file for forensics
+            try {
+                await fs.rename(filePath, `${filePath}.corrupted.${Date.now()}`);
+            }
+            catch { /* best-effort */ }
+            return emptyState();
+        }
+        throw err;
+    }
+}
+async function writeDispatchState(filePath, data) {
+    const dir = path.dirname(filePath);
+    if (!existsSync(dir))
+        mkdirSync(dir, { recursive: true });
+    // Trim processedEvents to avoid unbounded growth
+    if (data.processedEvents.length > MAX_PROCESSED_EVENTS) {
+        data.processedEvents = data.processedEvents.slice(-MAX_PROCESSED_EVENTS);
+    }
+    const tmpPath = filePath + ".tmp";
+    await fs.writeFile(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+    await fs.rename(tmpPath, filePath);
+}
+// ---------------------------------------------------------------------------
+// Atomic transitions (CAS)
+// ---------------------------------------------------------------------------
+export class TransitionError extends Error {
+    dispatchId;
+    fromStatus;
+    toStatus;
+    actualStatus;
+    constructor(dispatchId, fromStatus, toStatus, actualStatus) {
+        super(`CAS transition failed for ${dispatchId}: ` +
+            `expected ${fromStatus} → ${toStatus}, but current status is ${actualStatus}`);
+        this.dispatchId = dispatchId;
+        this.fromStatus = fromStatus;
+        this.toStatus = toStatus;
+        this.actualStatus = actualStatus;
+        this.name = "TransitionError";
+    }
+}
+/**
+ * Atomic compare-and-swap status transition.
+ * Rejects if current status doesn't match `fromStatus`.
+ * Returns the updated dispatch.
+ */
+export async function transitionDispatch(issueIdentifier, fromStatus, toStatus, updates, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        const dispatch = data.dispatches.active[issueIdentifier];
+        if (!dispatch) {
+            throw new Error(`No active dispatch for ${issueIdentifier}`);
+        }
+        if (dispatch.status !== fromStatus) {
+            throw new TransitionError(issueIdentifier, fromStatus, toStatus, dispatch.status);
+        }
+        const allowed = VALID_TRANSITIONS[fromStatus];
+        if (!allowed.includes(toStatus)) {
+            throw new Error(`Invalid transition: ${fromStatus} → ${toStatus}`);
+        }
+        dispatch.status = toStatus;
+        if (updates) {
+            if (updates.workerSessionKey !== undefined)
+                dispatch.workerSessionKey = updates.workerSessionKey;
+            if (updates.auditSessionKey !== undefined)
+                dispatch.auditSessionKey = updates.auditSessionKey;
+            if (updates.stuckReason !== undefined)
+                dispatch.stuckReason = updates.stuckReason;
+            if (updates.attempt !== undefined)
+                dispatch.attempt = updates.attempt;
+        }
+        await writeDispatchState(filePath, data);
+        return dispatch;
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+// ---------------------------------------------------------------------------
+// Session map operations
+// ---------------------------------------------------------------------------
+/**
+ * Register a session key → dispatch mapping.
+ * Called when spawning a worker or audit sub-agent.
+ */
+export async function registerSessionMapping(sessionKey, mapping, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        data.sessionMap[sessionKey] = mapping;
+        await writeDispatchState(filePath, data);
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+/**
+ * Lookup a session key in the map.
+ * Used by agent_end hook to identify dispatch context.
+ */
+export function lookupSessionMapping(state, sessionKey) {
+    return state.sessionMap[sessionKey] ?? null;
+}
+/**
+ * Remove a session mapping (cleanup after processing).
+ */
+export async function removeSessionMapping(sessionKey, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        delete data.sessionMap[sessionKey];
+        await writeDispatchState(filePath, data);
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+/**
+ * Check if an event has already been processed. If not, mark it.
+ * Returns true if the event is NEW (should be processed).
+ * Returns false if it's a duplicate (skip).
+ */
+export async function markEventProcessed(eventKey, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        if (data.processedEvents.includes(eventKey))
+            return false;
+        data.processedEvents.push(eventKey);
+        await writeDispatchState(filePath, data);
+        return true;
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+// ---------------------------------------------------------------------------
+// Legacy-compatible operations (still used by existing code)
+// ---------------------------------------------------------------------------
+export async function registerDispatch(issueIdentifier, dispatch, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        // Ensure v2 fields have defaults
+        if (dispatch.attempt === undefined)
+            dispatch.attempt = 0;
+        data.dispatches.active[issueIdentifier] = dispatch;
+        await writeDispatchState(filePath, data);
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+export async function completeDispatch(issueIdentifier, result, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        const active = data.dispatches.active[issueIdentifier];
+        // Clean up session mappings for this dispatch
+        for (const [key, mapping] of Object.entries(data.sessionMap)) {
+            if (mapping.dispatchId === issueIdentifier) {
+                delete data.sessionMap[key];
+            }
+        }
+        delete data.dispatches.active[issueIdentifier];
+        data.dispatches.completed[issueIdentifier] = {
+            issueIdentifier,
+            tier: active?.tier ?? result.tier,
+            status: result.status,
+            completedAt: result.completedAt,
+            prUrl: result.prUrl,
+            project: active?.project ?? result.project,
+            totalAttempts: active?.attempt ?? 0,
+            worktreePath: active?.worktreePath,
+        };
+        await writeDispatchState(filePath, data);
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+export async function updateDispatchStatus(issueIdentifier, status, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        const dispatch = data.dispatches.active[issueIdentifier];
+        if (dispatch) {
+            dispatch.status = status;
+            await writeDispatchState(filePath, data);
+        }
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+/**
+ * Persist a new task-flow revision back to the active dispatch record so
+ * subsequent bridge calls see the up-to-date `expectedRevision`. Best-effort:
+ * silently no-ops when the dispatch is no longer active or has no flow id.
+ */
+export async function updateDispatchTaskFlowRevision(issueIdentifier, revision, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        const dispatch = data.dispatches.active[issueIdentifier];
+        if (dispatch && dispatch.taskFlowId) {
+            dispatch.taskFlowRevision = revision;
+            await writeDispatchState(filePath, data);
+        }
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+export function getActiveDispatch(state, issueIdentifier) {
+    return state.dispatches.active[issueIdentifier] ?? null;
+}
+export function listActiveDispatches(state) {
+    return Object.values(state.dispatches.active);
+}
+export function listStaleDispatches(state, maxAgeMs) {
+    const now = Date.now();
+    return Object.values(state.dispatches.active).filter((d) => {
+        const age = now - new Date(d.dispatchedAt).getTime();
+        return age > maxAgeMs;
+    });
+}
+/**
+ * Find dispatches that need recovery after restart:
+ * - Status "working" with a workerSessionKey but no auditSessionKey
+ *   (worker completed but audit wasn't triggered before crash)
+ */
+export function listRecoverableDispatches(state) {
+    return Object.values(state.dispatches.active).filter((d) => d.status === "working" && d.workerSessionKey && !d.auditSessionKey);
+}
+/**
+ * Remove completed dispatches older than maxAgeMs.
+ * Returns the number of entries pruned.
+ */
+export async function pruneCompleted(maxAgeMs, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        const now = Date.now();
+        let pruned = 0;
+        for (const [key, entry] of Object.entries(data.dispatches.completed)) {
+            const age = now - new Date(entry.completedAt).getTime();
+            if (age > maxAgeMs) {
+                delete data.dispatches.completed[key];
+                pruned++;
+            }
+        }
+        if (pruned > 0)
+            await writeDispatchState(filePath, data);
+        return pruned;
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+/**
+ * Garbage-collect completed dispatches older than maxAgeMs.
+ * Convenience wrapper with a 7-day default.
+ * Returns the count of pruned entries.
+ */
+export async function pruneCompletedDispatches(maxAgeMs = 7 * 24 * 60 * 60_000, configPath) {
+    return pruneCompleted(maxAgeMs, configPath);
+}
+/**
+ * Remove an active dispatch (e.g. when worktree is gone and branch is gone).
+ */
+export async function removeActiveDispatch(issueIdentifier, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readDispatchState(configPath);
+        // Clean up session mappings for this dispatch
+        for (const [key, mapping] of Object.entries(data.sessionMap)) {
+            if (mapping.dispatchId === issueIdentifier) {
+                delete data.sessionMap[key];
+            }
+        }
+        delete data.dispatches.active[issueIdentifier];
+        await writeDispatchState(filePath, data);
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}

--- a/dist/src/pipeline/guidance.js
+++ b/dist/src/pipeline/guidance.js
@@ -1,0 +1,156 @@
+/**
+ * Linear workspace & team guidance extraction, caching, and formatting.
+ *
+ * Guidance is delivered via AgentSessionEvent webhook payloads (both the
+ * top-level `guidance` field and embedded within `promptContext`). This
+ * module extracts it, caches it per-team (so Comment webhook paths can
+ * benefit), and formats it as a prompt appendix.
+ *
+ * @see https://linear.app/docs/agents-in-linear
+ */
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+/**
+ * Extract guidance from an AgentSessionEvent webhook payload.
+ * Priority: payload.guidance (string) > parsed from payload.promptContext > null.
+ */
+export function extractGuidance(payload) {
+    // 1. Top-level guidance field (clean string from Linear)
+    const guidance = payload.guidance;
+    if (typeof guidance === "string" && guidance.trim()) {
+        return { guidance: guidance.trim(), source: "webhook" };
+    }
+    // 2. Try parsing from promptContext
+    const pc = payload.promptContext;
+    if (typeof pc === "string" && pc.trim()) {
+        const extracted = extractGuidanceFromPromptContext(pc);
+        if (extracted) {
+            return { guidance: extracted, source: "promptContext" };
+        }
+    }
+    return { guidance: null, source: null };
+}
+/**
+ * Best-effort parse guidance from a promptContext string.
+ * Linear's promptContext format may include guidance as XML-style tags
+ * or markdown-headed sections.
+ */
+export function extractGuidanceFromPromptContext(promptContext) {
+    // Pattern 1: XML-style tags (e.g. <guidance>...</guidance>)
+    const xmlMatch = promptContext.match(/<guidance>([\s\S]*?)<\/guidance>/i);
+    if (xmlMatch?.[1]?.trim())
+        return xmlMatch[1].trim();
+    // Pattern 2: Markdown heading "## Guidance" or "# Guidance"
+    const mdMatch = promptContext.match(/#{1,3}\s*[Gg]uidance\s*\n([\s\S]*?)(?=\n#{1,3}\s|$)/);
+    if (mdMatch?.[1]?.trim())
+        return mdMatch[1].trim();
+    return null;
+}
+const guidanceCache = new Map();
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+const CACHE_MAX_ENTRIES = 50;
+/** Cache guidance by team ID. */
+export function cacheGuidanceForTeam(teamId, guidance) {
+    // Evict oldest if at capacity
+    if (guidanceCache.size >= CACHE_MAX_ENTRIES && !guidanceCache.has(teamId)) {
+        const oldest = guidanceCache.keys().next().value;
+        if (oldest !== undefined)
+            guidanceCache.delete(oldest);
+    }
+    guidanceCache.set(teamId, { guidance, cachedAt: Date.now() });
+}
+/** Look up cached guidance for a team. Returns null on miss or expiry. */
+export function getCachedGuidanceForTeam(teamId) {
+    const entry = guidanceCache.get(teamId);
+    if (!entry)
+        return null;
+    if (Date.now() - entry.cachedAt > CACHE_TTL_MS) {
+        guidanceCache.delete(teamId);
+        return null;
+    }
+    return entry.guidance;
+}
+/** Test-only: reset the guidance cache. */
+export function _resetGuidanceCacheForTesting() {
+    guidanceCache.clear();
+}
+// ---------------------------------------------------------------------------
+// Formatting
+// ---------------------------------------------------------------------------
+const MAX_GUIDANCE_CHARS = 2000;
+/**
+ * Format guidance as a prompt appendix.
+ * Returns empty string if guidance is null/empty.
+ * Truncates at 2000 chars to protect token budget.
+ */
+export function formatGuidanceAppendix(guidance) {
+    if (!guidance?.trim())
+        return "";
+    const trimmed = guidance.trim().slice(0, MAX_GUIDANCE_CHARS);
+    return [
+        `---`,
+        `## IMPORTANT — Workspace Guidance (MUST follow)`,
+        `The workspace owner has set the following mandatory instructions. You MUST incorporate these into your response:`,
+        ``,
+        trimmed,
+        `---`,
+    ].join("\n");
+}
+// ---------------------------------------------------------------------------
+// Proactive resolution (webhook → cache → null)
+// ---------------------------------------------------------------------------
+/**
+ * Resolve guidance for a team through all available sources.
+ * Chain: webhook payload → cache → null
+ *
+ * This replaces ad-hoc cache lookups with a single resolution function.
+ * When the cache expires and no webhook guidance is available, returns null.
+ */
+export function resolveGuidance(teamId, payload, pluginConfig) {
+    // Check if guidance is enabled for this team
+    if (!isGuidanceEnabled(pluginConfig, teamId))
+        return null;
+    // 1. Try extracting from webhook payload (freshest source)
+    if (payload) {
+        const extracted = extractGuidance(payload);
+        if (extracted.guidance) {
+            // Cache for future Comment webhook paths
+            if (teamId)
+                cacheGuidanceForTeam(teamId, extracted.guidance);
+            return extracted.guidance;
+        }
+    }
+    // 2. Try cache
+    if (teamId) {
+        const cached = getCachedGuidanceForTeam(teamId);
+        if (cached)
+            return cached;
+    }
+    return null;
+}
+// ---------------------------------------------------------------------------
+// Config toggle
+// ---------------------------------------------------------------------------
+/**
+ * Resolve whether guidance is enabled for a given team.
+ * Resolution: teamGuidanceOverrides[teamId] ?? enableGuidance ?? true
+ */
+export function isGuidanceEnabled(pluginConfig, teamId) {
+    if (!pluginConfig)
+        return true;
+    // Check per-team override first
+    if (teamId) {
+        const overrides = pluginConfig.teamGuidanceOverrides;
+        if (overrides && typeof overrides === "object" && !Array.isArray(overrides)) {
+            const teamOverride = overrides[teamId];
+            if (typeof teamOverride === "boolean")
+                return teamOverride;
+        }
+    }
+    // Fall back to workspace-level toggle
+    const enabled = pluginConfig.enableGuidance;
+    if (typeof enabled === "boolean")
+        return enabled;
+    return true; // default on
+}

--- a/dist/src/pipeline/intent-classify.js
+++ b/dist/src/pipeline/intent-classify.js
@@ -1,0 +1,188 @@
+import { resolveDefaultAgent } from "../infra/shared-profiles.js";
+// ---------------------------------------------------------------------------
+// Valid intents (for validation)
+// ---------------------------------------------------------------------------
+const VALID_INTENTS = new Set([
+    "plan_start",
+    "plan_finalize",
+    "plan_abandon",
+    "plan_continue",
+    "ask_agent",
+    "request_work",
+    "question",
+    "close_issue",
+    "general",
+]);
+// ---------------------------------------------------------------------------
+// Classifier prompt
+// ---------------------------------------------------------------------------
+const CLASSIFY_PROMPT = `You are an intent classifier for a developer tool. Respond ONLY with JSON.
+
+Intents:
+- plan_start: user wants to begin project planning
+- plan_finalize: user wants to approve/finalize the plan (e.g. "looks good", "ship it", "approve plan")
+- plan_abandon: user wants to cancel/stop planning (e.g. "nevermind", "cancel this", "stop planning")
+- plan_continue: regular message during planning (default when planning is active)
+- ask_agent: user is addressing a specific agent by name
+- request_work: user wants something built, fixed, or implemented
+- question: user asking for information or help
+- close_issue: user wants to close/complete/resolve the issue (e.g. "close this", "mark as done", "resolved")
+- general: none of the above, automated messages, or noise
+
+Rules:
+- plan_start ONLY if the issue belongs to a project (hasProject=true)
+- If planning mode is active and no clear finalize/abandon intent, default to plan_continue
+- For ask_agent, set agentId to the matching name from Available agents
+- close_issue only for explicit closure requests, NOT ambiguous comments about resolution
+- One sentence reasoning`;
+// ---------------------------------------------------------------------------
+// Classify
+// ---------------------------------------------------------------------------
+/**
+ * Classify a comment's intent using a lightweight model.
+ *
+ * Uses `classifierAgentId` from plugin config (should point to a small/fast
+ * model like Haiku for low latency and cost). Falls back to the default
+ * agent if not configured.
+ *
+ * Falls back to regex patterns if the LLM call fails or returns invalid JSON.
+ */
+export async function classifyIntent(api, ctx, pluginConfig) {
+    const contextBlock = [
+        `Issue: "${ctx.issueTitle}" (status: ${ctx.issueStatus ?? "unknown"})`,
+        `Planning mode: ${ctx.isPlanning}`,
+        `Has project: ${ctx.hasProject}`,
+        `Available agents: ${ctx.agentNames.join(", ") || "none"}`,
+        `Comment: "${ctx.commentBody.slice(0, 500)}"`,
+    ].join("\n");
+    const message = `${CLASSIFY_PROMPT}\n\nContext:\n${contextBlock}\n\nRespond ONLY with: {"intent":"<intent>","agentId":"<if ask_agent>","reasoning":"<one sentence>"}`;
+    try {
+        const { runAgent } = await import("../agent/agent.js");
+        const classifierAgent = resolveClassifierAgent(api, pluginConfig);
+        const CLASSIFY_TIMEOUT_MS = 10_000;
+        const result = await Promise.race([
+            runAgent({
+                api,
+                agentId: classifierAgent,
+                sessionId: `intent-classify-${Date.now()}`,
+                message,
+                timeoutMs: CLASSIFY_TIMEOUT_MS,
+            }),
+            new Promise((_, reject) => setTimeout(() => reject(new Error("Intent classification timed out")), CLASSIFY_TIMEOUT_MS)),
+        ]);
+        if (result.output) {
+            const parsed = parseIntentResponse(result.output, ctx);
+            if (parsed) {
+                api.logger.info(`Intent classified: ${parsed.intent}${parsed.agentId ? ` (agent: ${parsed.agentId})` : ""} — ${parsed.reasoning}`);
+                return parsed;
+            }
+        }
+        if (!result.success) {
+            api.logger.warn(`Intent classifier agent failed: ${result.output.slice(0, 200)}`);
+        }
+        else {
+            api.logger.warn(`Intent classifier: could not parse response: ${result.output.slice(0, 200)}`);
+        }
+    }
+    catch (err) {
+        api.logger.warn(`Intent classifier error: ${err}`);
+    }
+    // Fallback to regex
+    const fallback = regexFallback(ctx);
+    api.logger.info(`Intent classifier fallback: ${fallback.intent} — ${fallback.reasoning}`);
+    return fallback;
+}
+// ---------------------------------------------------------------------------
+// Response parsing
+// ---------------------------------------------------------------------------
+function parseIntentResponse(raw, ctx) {
+    // Extract JSON using indexOf/lastIndexOf (more robust than regex for nested JSON)
+    const start = raw.indexOf("{");
+    const end = raw.lastIndexOf("}");
+    if (start === -1 || end === -1 || end <= start)
+        return null;
+    try {
+        const parsed = JSON.parse(raw.slice(start, end + 1));
+        const intent = parsed.intent;
+        if (!VALID_INTENTS.has(intent))
+            return null;
+        // Validate agentId for ask_agent
+        let agentId;
+        if (intent === "ask_agent" && parsed.agentId) {
+            const normalized = String(parsed.agentId).toLowerCase();
+            // Only accept agent names that actually exist
+            if (ctx.agentNames.some((n) => n.toLowerCase() === normalized)) {
+                agentId = normalized;
+            }
+            // If hallucinated name, clear agentId but keep the intent
+        }
+        return {
+            intent: intent,
+            agentId,
+            reasoning: parsed.reasoning ?? "no reasoning provided",
+            fromFallback: false,
+        };
+    }
+    catch {
+        return null;
+    }
+}
+// ---------------------------------------------------------------------------
+// Regex fallback (moved from planner.ts + webhook.ts)
+// ---------------------------------------------------------------------------
+// Planning intent patterns
+const PLAN_START_PATTERN = /\b(plan|planning)\s+(this\s+)(project|out)\b|\bplan\s+this\s+out\b/i;
+const FINALIZE_PATTERN = /\b(finalize\s+(the\s+)?plan\b|done\s+planning\b(?!\s+\w)|approve\s+(the\s+)?plan\b|plan\s+looks\s+good\b|ready\s+to\s+finalize\b|let'?s\s+finalize\b)/i;
+const ABANDON_PATTERN = /\b(abandon\s+plan(ning)?|cancel\s+plan(ning)?|stop\s+planning|exit\s+planning|quit\s+planning)\b/i;
+const CLOSE_ISSUE_PATTERN = /\b(close\s+(this|the\s+issue)|mark\s+(as\s+)?(done|completed?|resolved)|this\s+is\s+(done|resolved|completed?)|resolve\s+(this|the\s+issue))\b/i;
+export function regexFallback(ctx) {
+    const text = ctx.commentBody;
+    // Planning-specific patterns (only when planning is active or issue has project)
+    if (ctx.isPlanning) {
+        if (FINALIZE_PATTERN.test(text)) {
+            return { intent: "plan_finalize", reasoning: "regex: finalize pattern matched", fromFallback: true };
+        }
+        if (ABANDON_PATTERN.test(text)) {
+            return { intent: "plan_abandon", reasoning: "regex: abandon pattern matched", fromFallback: true };
+        }
+        // Default to plan_continue during planning
+        return { intent: "plan_continue", reasoning: "regex: planning mode active, default continue", fromFallback: true };
+    }
+    // Plan start (only if issue has a project)
+    if (ctx.hasProject && PLAN_START_PATTERN.test(text)) {
+        return { intent: "plan_start", reasoning: "regex: plan start pattern matched", fromFallback: true };
+    }
+    // Close issue detection
+    if (CLOSE_ISSUE_PATTERN.test(text)) {
+        return { intent: "close_issue", reasoning: "regex: close issue pattern matched", fromFallback: true };
+    }
+    // Agent name detection
+    if (ctx.agentNames.length > 0) {
+        const lower = text.toLowerCase();
+        for (const name of ctx.agentNames) {
+            if (lower.includes(name.toLowerCase())) {
+                return { intent: "ask_agent", agentId: name.toLowerCase(), reasoning: `regex: agent name "${name}" found in comment`, fromFallback: true };
+            }
+        }
+    }
+    // Default: general (no match)
+    return { intent: "general", reasoning: "regex: no pattern matched", fromFallback: true };
+}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+/**
+ * Resolve the agent to use for intent classification.
+ *
+ * Priority: pluginConfig.classifierAgentId → defaultAgentId → profile default.
+ * Configure classifierAgentId to point to a small/fast model (e.g. Haiku)
+ * for low-latency, low-cost classification.
+ */
+function resolveClassifierAgent(api, pluginConfig) {
+    // 1. Explicit classifier agent
+    const classifierAgent = pluginConfig?.classifierAgentId ?? api.pluginConfig?.classifierAgentId;
+    if (typeof classifierAgent === "string" && classifierAgent)
+        return classifierAgent;
+    // 2. Fall back to default agent
+    return resolveDefaultAgent(api);
+}

--- a/dist/src/pipeline/pipeline.js
+++ b/dist/src/pipeline/pipeline.js
@@ -1,0 +1,902 @@
+/**
+ * pipeline.ts — Dispatch pipeline v2: hook-driven with hard-enforced audit.
+ *
+ * v1 (runFullPipeline) ran plan→implement→audit in a single synchronous flow
+ * with the same agent self-certifying its own work.
+ *
+ * v2 splits into:
+ * - Worker phase: orchestrator spawns worker via plugin code, worker plans + implements
+ * - Audit phase: agent_end hook auto-triggers independent audit (runAgent)
+ * - Verdict phase: agent_end hook processes audit result → done/rework/stuck
+ *
+ * Prompts are loaded from prompts.yaml (sidecar file, customizable).
+ */
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import { runAgent } from "../agent/agent.js";
+import { clearActiveSession } from "./active-session.js";
+import { getCachedGuidanceForTeam, isGuidanceEnabled } from "./guidance.js";
+import { transitionDispatch, registerSessionMapping, markEventProcessed, completeDispatch, TransitionError, readDispatchState, getActiveDispatch, updateDispatchTaskFlowRevision, } from "./dispatch-state.js";
+import { recordPhaseTask, markFlowTerminal, markFlowWaiting, markFlowResumed, } from "./taskflow-bridge.js";
+import { onProjectIssueCompleted, onProjectIssueStuck } from "./dag-dispatch.js";
+import { saveWorkerOutput, saveAuditVerdict, appendLog, updateManifest, writeSummary, buildSummaryFromArtifacts, writeDispatchMemory, resolveOrchestratorWorkspace, } from "./artifacts.js";
+import { resolveWatchdogConfig } from "../agent/watchdog.js";
+import { emitDiagnostic } from "../infra/observability.js";
+import { renderTemplate } from "../infra/template.js";
+import { getWorktreeStatus, createPullRequest } from "../infra/codex-worktree.js";
+// ---------------------------------------------------------------------------
+// Linear issue state transitions (best-effort)
+// ---------------------------------------------------------------------------
+/**
+ * Transition a Linear issue to a target state by type (e.g., "started", "completed", "triage").
+ * Resolves the team's workflow states and finds a matching state.
+ * All transitions are best-effort — failures are logged as warnings, never thrown.
+ */
+async function transitionLinearIssueState(linearApi, issueId, teamId, targetStateType, opts, logger) {
+    if (!teamId) {
+        logger?.warn(`[linear-state] no teamId — skipping state transition to ${targetStateType}`);
+        return;
+    }
+    try {
+        const states = await linearApi.getTeamStates(teamId);
+        // Prefer a specific state name if provided, otherwise match by type
+        let target = opts?.preferredStateName
+            ? states.find(s => s.name === opts.preferredStateName) ?? states.find(s => s.type === targetStateType)
+            : states.find(s => s.type === targetStateType);
+        if (target) {
+            await linearApi.updateIssue(issueId, { stateId: target.id });
+            logger?.info(`[linear-state] ${issueId} → ${target.name} (type=${target.type})`);
+        }
+        else {
+            logger?.warn(`[linear-state] no state with type="${targetStateType}" found for team ${teamId}`);
+        }
+    }
+    catch (err) {
+        logger?.warn(`[linear-state] failed to transition ${issueId} to ${targetStateType}: ${err}`);
+    }
+}
+/**
+ * Transition a Linear issue to "In Review" if it exists, otherwise "Done".
+ * Used after audit pass when a PR was created.
+ */
+async function transitionToReviewOrDone(linearApi, issueId, teamId, hasPr, logger) {
+    if (!teamId)
+        return;
+    try {
+        const states = await linearApi.getTeamStates(teamId);
+        if (hasPr) {
+            // Prefer "In Review" state; fall back to any "started" state named "In Review", then "completed"
+            const inReview = states.find(s => s.name === "In Review")
+                ?? states.find(s => s.type === "started" && s.name.toLowerCase().includes("review"));
+            if (inReview) {
+                await linearApi.updateIssue(issueId, { stateId: inReview.id });
+                logger?.info(`[linear-state] ${issueId} → ${inReview.name} (PR created)`);
+                return;
+            }
+        }
+        // No PR or no "In Review" state — mark as Done
+        const done = states.find(s => s.type === "completed");
+        if (done) {
+            await linearApi.updateIssue(issueId, { stateId: done.id });
+            logger?.info(`[linear-state] ${issueId} → ${done.name} (completed)`);
+        }
+    }
+    catch (err) {
+        logger?.warn(`[linear-state] failed to transition ${issueId} to review/done: ${err}`);
+    }
+}
+const DEFAULT_PROMPTS = {
+    worker: {
+        system: "You are a coding worker implementing a Linear issue. Your ONLY job is to write code and return a text summary. Do NOT attempt to update, close, comment on, or modify the Linear issue. Do NOT mark the issue as Done.",
+        task: "Implement issue {{identifier}}: {{title}}\n\nIssue body:\n{{description}}\n\nWorktree: {{worktreePath}}\n{{projectContext}}\n\nBefore coding, read CLAUDE.md and AGENTS.md in the worktree root for project conventions and guidelines. If they don't exist, explore the codebase first.\n\nImplement the solution, run tests, commit your work, and return a text summary.",
+    },
+    audit: {
+        system: "You are an independent auditor. The Linear issue body is the SOURCE OF TRUTH. Worker comments are secondary evidence.",
+        task: 'Audit issue {{identifier}}: {{title}}\n\nIssue body:\n{{description}}\n\nWorktree: {{worktreePath}}\n{{projectContext}}\n\nRead CLAUDE.md and AGENTS.md in the worktree root for project standards.\n\nReturn JSON verdict: {"pass": true/false, "criteria": [...], "gaps": [...], "testResults": "..."}',
+    },
+    rework: {
+        addendum: "PREVIOUS AUDIT FAILED (attempt {{attempt}}). Gaps:\n{{gaps}}\n\nAddress these specific issues. Preserve correct code from prior attempts.",
+    },
+};
+let _cachedGlobalPrompts = null;
+const _projectPromptCache = new Map();
+/**
+ * Merge two prompt layers. Overlay replaces individual fields per section
+ * (shallow section-level merge, not deep).
+ */
+function mergePromptLayers(base, overlay) {
+    return {
+        worker: { ...base.worker, ...overlay.worker },
+        audit: { ...base.audit, ...overlay.audit },
+        rework: { ...base.rework, ...overlay.rework },
+    };
+}
+/**
+ * Load and parse the raw prompts YAML file (global promptsPath or sidecar).
+ * Returns the parsed object, or null if no file found.
+ * Shared by both pipeline and planner prompt loaders.
+ */
+export function loadRawPromptYaml(pluginConfig) {
+    try {
+        const customPath = pluginConfig?.promptsPath;
+        let raw;
+        if (customPath) {
+            const resolved = customPath.startsWith("~")
+                ? customPath.replace("~", process.env.HOME ?? "")
+                : customPath;
+            raw = readFileSync(resolved, "utf-8");
+        }
+        else {
+            const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+            raw = readFileSync(join(pluginRoot, "prompts.yaml"), "utf-8");
+        }
+        return parseYaml(raw);
+    }
+    catch {
+        return null;
+    }
+}
+/**
+ * Load global prompts (layers 1+2: hardcoded defaults + global promptsPath override).
+ * Cached after first load.
+ */
+function loadGlobalPrompts(pluginConfig) {
+    if (_cachedGlobalPrompts)
+        return _cachedGlobalPrompts;
+    const parsed = loadRawPromptYaml(pluginConfig);
+    if (parsed) {
+        _cachedGlobalPrompts = mergePromptLayers(DEFAULT_PROMPTS, parsed);
+    }
+    else {
+        _cachedGlobalPrompts = DEFAULT_PROMPTS;
+    }
+    return _cachedGlobalPrompts;
+}
+/**
+ * Load prompts with three-layer merge:
+ * 1. Built-in defaults (hardcoded DEFAULT_PROMPTS)
+ * 2. Global override (promptsPath or sidecar prompts.yaml)
+ * 3. Per-project override ({worktreePath}/.claw/prompts.yaml) — optional
+ */
+export function loadPrompts(pluginConfig, worktreePath) {
+    const global = loadGlobalPrompts(pluginConfig);
+    if (!worktreePath)
+        return global;
+    // Check per-project cache
+    const cached = _projectPromptCache.get(worktreePath);
+    if (cached)
+        return cached;
+    // Try loading per-project prompts
+    try {
+        const projectPromptsPath = join(worktreePath, ".claw", "prompts.yaml");
+        const raw = readFileSync(projectPromptsPath, "utf-8");
+        const parsed = parseYaml(raw);
+        const merged = mergePromptLayers(global, parsed);
+        _projectPromptCache.set(worktreePath, merged);
+        return merged;
+    }
+    catch {
+        // No per-project override — use global
+        return global;
+    }
+}
+/** Clear prompt cache (for testing or after config change) */
+export function clearPromptCache() {
+    _cachedGlobalPrompts = null;
+    _projectPromptCache.clear();
+}
+// ---------------------------------------------------------------------------
+// Project context builder
+// ---------------------------------------------------------------------------
+/**
+ * Build a project context block from plugin config.
+ *
+ * Provides structural info only: project name and repo paths.
+ * Framework, build/test commands, and conventions belong in CLAUDE.md
+ * and AGENTS.md in the repo root — agents are instructed to read those.
+ */
+export function buildProjectContext(pluginConfig) {
+    if (!pluginConfig)
+        return "";
+    const lines = [];
+    // Project name
+    const projectName = pluginConfig.projectName;
+    if (projectName)
+        lines.push(`Project: ${projectName}`);
+    // Repo(s)
+    const repos = pluginConfig.repos;
+    const baseRepo = pluginConfig.codexBaseRepo;
+    if (repos && Object.keys(repos).length > 0) {
+        lines.push(`Repos: ${Object.entries(repos).map(([k, v]) => `${k} (${v})`).join(", ")}`);
+    }
+    else if (baseRepo) {
+        lines.push(`Repo: ${baseRepo}`);
+    }
+    if (lines.length === 0)
+        return "";
+    return "## Project Context\n" + lines.join("\n");
+}
+/**
+ * Build the task prompt for a worker sub-agent (sessions_spawn).
+ * Includes rework addendum if attempt > 0.
+ */
+export function buildWorkerTask(issue, worktreePath, opts) {
+    const prompts = loadPrompts(opts?.pluginConfig, worktreePath);
+    const vars = {
+        identifier: issue.identifier,
+        title: issue.title,
+        description: issue.description ?? "(no description)",
+        worktreePath,
+        tier: "",
+        attempt: String(opts?.attempt ?? 0),
+        gaps: opts?.gaps?.length ? "- " + opts.gaps.join("\n- ") : "",
+        guidance: opts?.guidance
+            ? `\n---\n## IMPORTANT — Workspace Guidance (MUST follow)\nThe workspace owner has set the following mandatory instructions. You MUST incorporate these into your response:\n\n${opts.guidance.slice(0, 2000)}\n---`
+            : "",
+        projectContext: buildProjectContext(opts?.pluginConfig),
+        teamContext: opts?.teamContext ?? "",
+    };
+    let task = renderTemplate(prompts.worker.task, vars);
+    if ((opts?.attempt ?? 0) > 0 && opts?.gaps?.length) {
+        task += "\n\n" + renderTemplate(prompts.rework.addendum, vars);
+    }
+    return {
+        system: renderTemplate(prompts.worker.system, vars),
+        task,
+    };
+}
+/**
+ * Build the task prompt for an audit sub-agent (runAgent).
+ */
+export function buildAuditTask(issue, worktreePath, pluginConfig, opts) {
+    const prompts = loadPrompts(pluginConfig, worktreePath);
+    const vars = {
+        identifier: issue.identifier,
+        title: issue.title,
+        description: issue.description ?? "(no description)",
+        worktreePath,
+        tier: "",
+        attempt: "0",
+        gaps: "",
+        guidance: opts?.guidance
+            ? `\n---\n## IMPORTANT — Workspace Guidance (MUST follow)\nThe workspace owner has set the following mandatory instructions. You MUST incorporate these into your response:\n\n${opts.guidance.slice(0, 2000)}\n---`
+            : "",
+        projectContext: buildProjectContext(pluginConfig),
+        teamContext: opts?.teamContext ?? "",
+    };
+    return {
+        system: renderTemplate(prompts.audit.system, vars),
+        task: renderTemplate(prompts.audit.task, vars),
+    };
+}
+/**
+ * Parse the audit verdict JSON from the agent's output.
+ * Looks for the last JSON object in the output that matches the verdict shape.
+ */
+export function parseVerdict(output) {
+    // Try to find JSON in the output (last occurrence)
+    const jsonMatches = output.match(/\{[^{}]*"pass"\s*:\s*(true|false)[^{}]*\}/g);
+    if (!jsonMatches?.length)
+        return null;
+    for (const match of jsonMatches.reverse()) {
+        try {
+            const parsed = JSON.parse(match);
+            if (typeof parsed.pass === "boolean") {
+                return {
+                    pass: parsed.pass,
+                    criteria: Array.isArray(parsed.criteria) ? parsed.criteria : [],
+                    gaps: Array.isArray(parsed.gaps) ? parsed.gaps : [],
+                    testResults: typeof parsed.testResults === "string" ? parsed.testResults : "",
+                };
+            }
+        }
+        catch { /* try next match */ }
+    }
+    return null;
+}
+/**
+ * Triggered by agent_end hook when a worker sub-agent completes.
+ * Transitions dispatch to "auditing" and spawns an independent audit agent.
+ *
+ * Idempotent: uses CAS transition + event dedup.
+ */
+export async function triggerAudit(hookCtx, dispatch, event, sessionKey) {
+    const { api, linearApi, notify, pluginConfig, configPath } = hookCtx;
+    const TAG = `[${dispatch.issueIdentifier}]`;
+    // Dedup check
+    const eventKey = `worker-end:${sessionKey}`;
+    const isNew = await markEventProcessed(eventKey, configPath);
+    if (!isNew) {
+        api.logger.info(`${TAG} duplicate worker agent_end, skipping`);
+        return;
+    }
+    // CAS transition: working → auditing
+    try {
+        await transitionDispatch(dispatch.issueIdentifier, "working", "auditing", undefined, configPath);
+    }
+    catch (err) {
+        if (err instanceof TransitionError) {
+            api.logger.warn(`${TAG} CAS failed for audit trigger: ${err.message}`);
+            return;
+        }
+        throw err;
+    }
+    api.logger.info(`${TAG} worker completed, triggering audit (attempt ${dispatch.attempt})`);
+    emitDiagnostic(api, { event: "phase_transition", identifier: dispatch.issueIdentifier, from: "working", to: "auditing", attempt: dispatch.attempt });
+    // Mirror the worker→audit transition into the openclaw task-flow registry.
+    // setWaiting parks the managed flow on "audit" so any task-aware UI can
+    // see that the dispatch is between phases. Persist the bumped revision so
+    // subsequent calls (recordPhaseTask + markFlowTerminal) read the right
+    // expectedRevision from disk.
+    const dispatchAfterWait = markFlowWaiting(api, dispatch, "audit");
+    if (dispatchAfterWait.taskFlowRevision !== dispatch.taskFlowRevision && dispatchAfterWait.taskFlowRevision != null) {
+        await updateDispatchTaskFlowRevision(dispatch.issueIdentifier, dispatchAfterWait.taskFlowRevision, configPath);
+    }
+    // Update .claw/ manifest
+    try {
+        updateManifest(dispatch.worktreePath, { status: "auditing", attempts: dispatch.attempt });
+    }
+    catch { }
+    // Fetch fresh issue details for audit context
+    const issueDetails = await linearApi.getIssueDetails(dispatch.issueId).catch(() => null);
+    const issue = {
+        id: dispatch.issueId,
+        identifier: dispatch.issueIdentifier,
+        title: issueDetails?.title ?? dispatch.issueIdentifier,
+        description: issueDetails?.description,
+    };
+    // Build audit prompt from YAML templates
+    // For multi-repo dispatches, render worktreePath as a list of repo→path mappings
+    const effectiveAuditPath = dispatch.worktrees
+        ? dispatch.worktrees.map(w => `${w.repoName}: ${w.path}`).join("\n")
+        : dispatch.worktreePath;
+    // Look up cached guidance for audit
+    const auditTeamId = issueDetails?.team?.id;
+    const auditTeamKey = issueDetails?.team?.key;
+    const auditGuidance = (auditTeamId && isGuidanceEnabled(pluginConfig, auditTeamId))
+        ? getCachedGuidanceForTeam(auditTeamId) ?? undefined
+        : undefined;
+    // Resolve team context from teamMappings config
+    const auditTeamMappings = pluginConfig?.teamMappings;
+    const auditTeamMapping = auditTeamKey ? auditTeamMappings?.[auditTeamKey] : undefined;
+    const auditTeamContext = auditTeamMapping?.context
+        ? `\n## Team Context (${auditTeamKey})\n${auditTeamMapping.context}\n`
+        : "";
+    const auditPrompt = buildAuditTask(issue, effectiveAuditPath, pluginConfig, { guidance: auditGuidance, teamContext: auditTeamContext });
+    // Set Linear label
+    await linearApi.emitActivity(dispatch.agentSessionId ?? "", {
+        type: "thought",
+        body: `Audit triggered for ${dispatch.issueIdentifier} (attempt ${dispatch.attempt})`,
+    }).catch(() => { });
+    await notify("auditing", {
+        identifier: dispatch.issueIdentifier,
+        title: issue.title,
+        status: "auditing",
+        attempt: dispatch.attempt,
+    });
+    // Spawn audit agent via runAgent (deterministic, plugin-level — NOT sessions_spawn)
+    const auditSessionId = `linear-audit-${dispatch.issueIdentifier}-${dispatch.attempt}`;
+    // Register session mapping so the agent_end hook can find this dispatch
+    await registerSessionMapping(auditSessionId, {
+        dispatchId: dispatch.issueIdentifier,
+        phase: "audit",
+        attempt: dispatch.attempt,
+    }, configPath);
+    // Update dispatch with audit session key
+    const state = await readDispatchState(configPath);
+    const activeDispatch = getActiveDispatch(state, dispatch.issueIdentifier);
+    if (activeDispatch) {
+        activeDispatch.auditSessionKey = auditSessionId;
+    }
+    // Resolve audit agent: team mapping → plugin default
+    const auditDefaultAgentId = pluginConfig?.defaultAgentId ?? "default";
+    let auditAgentId = auditDefaultAgentId;
+    if (auditTeamKey) {
+        const auditTeamDefault = auditTeamMappings?.[auditTeamKey]?.defaultAgent;
+        if (typeof auditTeamDefault === "string") {
+            auditAgentId = auditTeamDefault;
+            api.logger.info(`${TAG} audit agent routed to ${auditAgentId} via team mapping (${auditTeamKey})`);
+        }
+    }
+    api.logger.info(`${TAG} spawning audit agent session=${auditSessionId}`);
+    // Mirror the audit phase into the openclaw task-flow registry. Best-effort.
+    recordPhaseTask(api, dispatch, "audit", auditAgentId, auditSessionId);
+    const result = await runAgent({
+        api,
+        agentId: auditAgentId,
+        sessionId: auditSessionId,
+        message: `${auditPrompt.system}\n\n${auditPrompt.task}`,
+        streaming: dispatch.agentSessionId
+            ? { linearApi, agentSessionId: dispatch.agentSessionId }
+            : undefined,
+    });
+    // runAgent returns inline (embedded runner) — process verdict directly.
+    // The agent_end hook in index.ts serves as safety net for sessions_spawn.
+    api.logger.info(`${TAG} audit completed inline (${result.output.length} chars, success=${result.success})`);
+    await processVerdict(hookCtx, dispatch, {
+        success: result.success,
+        output: result.output,
+    }, auditSessionId);
+}
+/**
+ * Triggered by agent_end hook when an audit sub-agent completes.
+ * Parses the verdict and transitions dispatch accordingly.
+ *
+ * Idempotent: uses CAS transition + event dedup.
+ */
+export async function processVerdict(hookCtx, dispatch, event, sessionKey) {
+    const { api, linearApi, notify, pluginConfig, configPath } = hookCtx;
+    const TAG = `[${dispatch.issueIdentifier}]`;
+    const maxAttempts = pluginConfig?.maxReworkAttempts ?? 2;
+    // Dedup check
+    const eventKey = `audit-end:${sessionKey}`;
+    const isNew = await markEventProcessed(eventKey, configPath);
+    if (!isNew) {
+        api.logger.info(`${TAG} duplicate audit agent_end, skipping`);
+        return;
+    }
+    // Extract output from event messages or direct output
+    let auditOutput = event.output ?? "";
+    if (!auditOutput && Array.isArray(event.messages)) {
+        // Get the last assistant message
+        for (const msg of [...event.messages].reverse()) {
+            if (msg?.role === "assistant" && typeof msg?.content === "string") {
+                auditOutput = msg.content;
+                break;
+            }
+            // Handle array content (tool use + text blocks)
+            if (msg?.role === "assistant" && Array.isArray(msg?.content)) {
+                for (const block of msg.content) {
+                    if (block?.type === "text" && typeof block?.text === "string") {
+                        auditOutput = block.text;
+                    }
+                }
+                if (auditOutput)
+                    break;
+            }
+        }
+    }
+    // Log audit interaction to .claw/
+    try {
+        appendLog(dispatch.worktreePath, {
+            ts: new Date().toISOString(), phase: "audit", attempt: dispatch.attempt,
+            agent: "auditor", prompt: "(audit task)",
+            outputPreview: auditOutput.slice(0, 500), success: event.success,
+        });
+    }
+    catch { }
+    // Parse verdict
+    const verdict = parseVerdict(auditOutput);
+    if (!verdict) {
+        api.logger.warn(`${TAG} could not parse audit verdict from output (${auditOutput.length} chars)`);
+        // Post comment so user knows what happened
+        await linearApi.createComment(dispatch.issueId, `## Audit Inconclusive\n\nThe auditor's response couldn't be parsed as a verdict. **Retrying automatically** — this usually resolves itself.\n\n**If it keeps happening:** \`openclaw openclaw-linear prompts validate\`\n\n**Status:** Retrying audit now. No action needed.`).catch((err) => api.logger.error(`${TAG} failed to post inconclusive comment: ${err}`));
+        // Treat unparseable verdict as failure
+        await handleAuditFail(hookCtx, dispatch, {
+            pass: false,
+            criteria: [],
+            gaps: ["Audit produced no parseable verdict"],
+            testResults: "",
+        });
+        return;
+    }
+    api.logger.info(`${TAG} audit verdict: ${verdict.pass ? "PASS" : "FAIL"} ` +
+        `(criteria: ${verdict.criteria.length}, gaps: ${verdict.gaps.length})`);
+    if (verdict.pass) {
+        await handleAuditPass(hookCtx, dispatch, verdict);
+    }
+    else {
+        await handleAuditFail(hookCtx, dispatch, verdict);
+    }
+}
+// ---------------------------------------------------------------------------
+// Verdict handlers
+// ---------------------------------------------------------------------------
+async function handleAuditPass(hookCtx, dispatch, verdict) {
+    const { api, linearApi, notify, pluginConfig, configPath } = hookCtx;
+    const TAG = `[${dispatch.issueIdentifier}]`;
+    // Save audit verdict to .claw/
+    try {
+        saveAuditVerdict(dispatch.worktreePath, dispatch.attempt, verdict);
+    }
+    catch { }
+    try {
+        updateManifest(dispatch.worktreePath, { status: "done", attempts: dispatch.attempt + 1 });
+    }
+    catch { }
+    // CAS transition: auditing → done
+    try {
+        await transitionDispatch(dispatch.issueIdentifier, "auditing", "done", undefined, configPath);
+    }
+    catch (err) {
+        if (err instanceof TransitionError) {
+            api.logger.warn(`${TAG} CAS failed for audit pass: ${err.message}`);
+            return;
+        }
+        throw err;
+    }
+    // Build summary from .claw/ artifacts and write to memory (before PR so body can include it)
+    let summary = null;
+    try {
+        summary = buildSummaryFromArtifacts(dispatch.worktreePath);
+        if (summary) {
+            writeSummary(dispatch.worktreePath, summary);
+            const wsDir = resolveOrchestratorWorkspace(api, pluginConfig);
+            writeDispatchMemory(dispatch.issueIdentifier, summary, wsDir, {
+                title: dispatch.issueTitle ?? dispatch.issueIdentifier,
+                tier: dispatch.tier,
+                status: "done",
+                project: dispatch.project,
+                attempts: dispatch.attempt + 1,
+                model: dispatch.model,
+            });
+            api.logger.info(`${TAG} .claw/ summary and memory written`);
+        }
+    }
+    catch (err) {
+        api.logger.warn(`${TAG} failed to write summary/memory: ${err}`);
+    }
+    // Auto-PR creation (best-effort, non-fatal)
+    let prUrl = null;
+    try {
+        const wtStatus = getWorktreeStatus(dispatch.worktreePath);
+        if (wtStatus.lastCommit) {
+            const prBody = [
+                `Fixes ${dispatch.issueIdentifier}`,
+                "",
+                "## What changed",
+                summary?.slice(0, 2000) ?? "(see audit verdict)",
+                "",
+                "## Audit",
+                `- **Criteria:** ${verdict.criteria.join(", ") || "N/A"}`,
+                `- **Tests:** ${verdict.testResults || "N/A"}`,
+                "",
+                `*Auto-generated by OpenClaw dispatch pipeline*`,
+            ].join("\n");
+            const prResult = createPullRequest(dispatch.worktreePath, `${dispatch.issueIdentifier}: ${dispatch.issueTitle ?? "implementation"}`, prBody);
+            prUrl = prResult.prUrl;
+            api.logger.info(`${TAG} PR created: ${prUrl}`);
+        }
+        else {
+            api.logger.info(`${TAG} no commits in worktree — skipping PR creation`);
+        }
+    }
+    catch (err) {
+        api.logger.warn(`${TAG} PR creation failed (non-fatal): ${err}`);
+    }
+    // Mirror terminal state into the openclaw task-flow registry first so the
+    // managed flow finishes BEFORE we lose the active dispatch record.
+    markFlowTerminal(api, dispatch, "done");
+    // Move to completed (include prUrl if PR was created)
+    await completeDispatch(dispatch.issueIdentifier, {
+        tier: dispatch.tier,
+        status: "done",
+        completedAt: new Date().toISOString(),
+        project: dispatch.project,
+        prUrl: prUrl ?? undefined,
+    }, configPath);
+    // Linear state transition: "In Review" if PR was created, otherwise "Done"
+    const issueDetails = await linearApi.getIssueDetails(dispatch.issueId).catch(() => null);
+    const teamId = issueDetails?.team?.id;
+    await transitionToReviewOrDone(linearApi, dispatch.issueId, teamId, !!prUrl, api.logger);
+    // Post approval comment (with summary excerpt and PR link if available)
+    const criteriaList = verdict.criteria.map((c) => `- ${c}`).join("\n");
+    const summaryExcerpt = summary ? `\n\n**Summary:**\n${summary.slice(0, 2000)}` : "";
+    const prLine = prUrl ? `\n- **Pull request:** ${prUrl}` : "";
+    await linearApi.createComment(dispatch.issueId, `## Done\n\nThis issue has been implemented and verified.\n\n**What was checked:**\n${criteriaList}\n\n**Test results:** ${verdict.testResults || "N/A"}${summaryExcerpt}${prLine}\n\n---\n*Completed on attempt ${dispatch.attempt + 1}.*\n\n**Next steps:**\n- Review the code: \`cd ${dispatch.worktreePath}\`\n- View artifacts: \`ls ${dispatch.worktreePath}/.claw/\`${prUrl ? "" : "\n- Create a PR from the worktree branch if one wasn't opened automatically"}`).catch((err) => api.logger.error(`${TAG} failed to post audit pass comment: ${err}`));
+    api.logger.info(`${TAG} audit PASSED — dispatch completed (attempt ${dispatch.attempt})`);
+    emitDiagnostic(api, {
+        event: "verdict_processed",
+        identifier: dispatch.issueIdentifier,
+        issueId: dispatch.issueId,
+        phase: "done",
+        attempt: dispatch.attempt,
+        tier: dispatch.tier,
+        agentId: pluginConfig?.defaultAgentId ?? "default",
+    });
+    await notify("audit_pass", {
+        identifier: dispatch.issueIdentifier,
+        title: dispatch.issueIdentifier,
+        status: "done",
+        attempt: dispatch.attempt,
+        verdict: { pass: true, gaps: [] },
+    });
+    // DAG cascade: if this issue belongs to a project dispatch, check for newly unblocked issues
+    if (dispatch.project) {
+        void onProjectIssueCompleted(hookCtx, dispatch.project, dispatch.issueIdentifier)
+            .catch((err) => api.logger.error(`${TAG} DAG cascade error: ${err}`));
+    }
+    clearActiveSession(dispatch.issueId);
+}
+async function handleAuditFail(hookCtx, dispatch, verdict) {
+    const { api, linearApi, notify, pluginConfig, configPath } = hookCtx;
+    const TAG = `[${dispatch.issueIdentifier}]`;
+    const maxAttempts = pluginConfig?.maxReworkAttempts ?? 2;
+    const nextAttempt = dispatch.attempt + 1;
+    // Save audit verdict to .claw/ (both escalation and rework paths)
+    try {
+        saveAuditVerdict(dispatch.worktreePath, dispatch.attempt, verdict);
+    }
+    catch { }
+    if (nextAttempt > maxAttempts) {
+        // Escalate — too many failures
+        try {
+            updateManifest(dispatch.worktreePath, { status: "stuck", attempts: nextAttempt });
+        }
+        catch { }
+        try {
+            await transitionDispatch(dispatch.issueIdentifier, "auditing", "stuck", { stuckReason: `audit_failed_${nextAttempt}x` }, configPath);
+        }
+        catch (err) {
+            if (err instanceof TransitionError) {
+                api.logger.warn(`${TAG} CAS failed for stuck transition: ${err.message}`);
+                return;
+            }
+            throw err;
+        }
+        // Write summary + memory for stuck dispatches too
+        try {
+            const summary = buildSummaryFromArtifacts(dispatch.worktreePath);
+            if (summary) {
+                writeSummary(dispatch.worktreePath, summary);
+                const wsDir = resolveOrchestratorWorkspace(api, pluginConfig);
+                writeDispatchMemory(dispatch.issueIdentifier, summary, wsDir, {
+                    title: dispatch.issueTitle ?? dispatch.issueIdentifier,
+                    tier: dispatch.tier,
+                    status: "stuck",
+                    project: dispatch.project,
+                    attempts: nextAttempt,
+                    model: dispatch.model,
+                });
+            }
+        }
+        catch { }
+        // Linear state transition: move to "Triage" so it shows up for human review
+        const stuckIssueDetails = await linearApi.getIssueDetails(dispatch.issueId).catch(() => null);
+        await transitionLinearIssueState(linearApi, dispatch.issueId, stuckIssueDetails?.team?.id, "triage", undefined, api.logger);
+        const gapsList = verdict.gaps.map((g) => `- ${g}`).join("\n");
+        await linearApi.createComment(dispatch.issueId, `## Needs Your Help\n\nAll ${nextAttempt} attempts failed. The agent couldn't resolve these issues on its own.\n\n**What went wrong:**\n${gapsList}\n\n**Test results:** ${verdict.testResults || "N/A"}\n\n---\n\n**What you can do:**\n1. **Clarify requirements** — update the issue body with more detail, then re-assign to try again\n2. **Fix it manually** — the agent's work is in the worktree: \`cd ${dispatch.worktreePath}\`\n3. **Force retry** — \`/dispatch retry ${dispatch.issueIdentifier}\`\n4. **View logs** — worker output: \`.claw/worker-*.md\`, audit verdicts: \`.claw/audit-*.json\``).catch((err) => api.logger.error(`${TAG} failed to post escalation comment: ${err}`));
+        api.logger.warn(`${TAG} audit FAILED ${nextAttempt}x — escalating to human`);
+        // Mirror terminal-failed into the openclaw task-flow registry.
+        markFlowTerminal(api, dispatch, "failed", `audit failed ${nextAttempt}x`);
+        emitDiagnostic(api, {
+            event: "verdict_processed",
+            identifier: dispatch.issueIdentifier,
+            issueId: dispatch.issueId,
+            phase: "stuck",
+            attempt: nextAttempt,
+            tier: dispatch.tier,
+            agentId: pluginConfig?.defaultAgentId ?? "default",
+        });
+        await notify("escalation", {
+            identifier: dispatch.issueIdentifier,
+            title: dispatch.issueIdentifier,
+            status: "stuck",
+            attempt: nextAttempt,
+            reason: `audit failed ${nextAttempt}x`,
+            verdict: { pass: false, gaps: verdict.gaps },
+        });
+        // DAG cascade: mark this issue as stuck in the project dispatch
+        if (dispatch.project) {
+            void onProjectIssueStuck(hookCtx, dispatch.project, dispatch.issueIdentifier)
+                .catch((err) => api.logger.error(`${TAG} DAG stuck cascade error: ${err}`));
+        }
+        return;
+    }
+    // Rework — transition back to working with incremented attempt
+    try {
+        await transitionDispatch(dispatch.issueIdentifier, "auditing", "working", { attempt: nextAttempt }, configPath);
+    }
+    catch (err) {
+        if (err instanceof TransitionError) {
+            api.logger.warn(`${TAG} CAS failed for rework transition: ${err.message}`);
+            return;
+        }
+        throw err;
+    }
+    // Mirror the rework transition into the openclaw task-flow registry —
+    // resume the managed flow back into the running state with currentStep
+    // reflecting the rework attempt counter. Persist the bumped revision so
+    // the next markFlowTerminal call sees the right expectedRevision.
+    const dispatchAfterResume = markFlowResumed(api, dispatch, `worker (rework attempt ${nextAttempt + 1})`);
+    if (dispatchAfterResume.taskFlowRevision !== dispatch.taskFlowRevision && dispatchAfterResume.taskFlowRevision != null) {
+        await updateDispatchTaskFlowRevision(dispatch.issueIdentifier, dispatchAfterResume.taskFlowRevision, configPath);
+    }
+    const gapsList = verdict.gaps.map((g) => `- ${g}`).join("\n");
+    await linearApi.createComment(dispatch.issueId, `## Needs More Work\n\nThe audit found gaps. **Retrying now** — the worker gets the feedback below as context.\n\n**Attempt ${nextAttempt} of ${maxAttempts + 1}** — ${maxAttempts + 1 - nextAttempt > 0 ? `${maxAttempts + 1 - nextAttempt} more ${maxAttempts + 1 - nextAttempt === 1 ? "retry" : "retries"} if this fails too` : "this is the last attempt"}.\n\n**What needs fixing:**\n${gapsList}\n\n**Test results:** ${verdict.testResults || "N/A"}\n\n**Status:** Worker is restarting with the gaps above as context. No action needed unless all retries fail.`).catch((err) => api.logger.error(`${TAG} failed to post rework comment: ${err}`));
+    api.logger.info(`${TAG} audit FAILED — rework attempt ${nextAttempt}/${maxAttempts + 1}`);
+    emitDiagnostic(api, { event: "phase_transition", identifier: dispatch.issueIdentifier, from: "auditing", to: "working", attempt: nextAttempt });
+    await notify("audit_fail", {
+        identifier: dispatch.issueIdentifier,
+        title: dispatch.issueIdentifier,
+        status: "working",
+        attempt: nextAttempt,
+        verdict: { pass: false, gaps: verdict.gaps },
+    });
+    // The webhook handler or dispatch service should re-spawn a worker
+    // with the rework context. Log emitted for observability.
+    api.logger.info(`${TAG} dispatch is back in "working" state (attempt ${nextAttempt}). ` +
+        `Orchestrator should re-spawn worker with gaps: ${verdict.gaps.join(", ")}`);
+}
+// ---------------------------------------------------------------------------
+// Worker phase (called by handleDispatch in webhook.ts)
+// ---------------------------------------------------------------------------
+/**
+ * Spawn the worker agent for a dispatch.
+ * Transitions dispatched→working, builds task, runs agent, then triggers audit.
+ *
+ * This is the main entry point for the v2 pipeline — replaces runFullPipeline.
+ */
+export async function spawnWorker(hookCtx, dispatch, opts) {
+    const { api, linearApi, pluginConfig, configPath } = hookCtx;
+    const TAG = `[${dispatch.issueIdentifier}]`;
+    // Transition dispatched → working (first run) — skip if already working (rework)
+    if (dispatch.status === "dispatched") {
+        try {
+            await transitionDispatch(dispatch.issueIdentifier, "dispatched", "working", undefined, configPath);
+        }
+        catch (err) {
+            if (err instanceof TransitionError) {
+                api.logger.warn(`${TAG} CAS failed for worker spawn: ${err.message}`);
+                return;
+            }
+            throw err;
+        }
+    }
+    // Fetch fresh issue details
+    const issueDetails = await linearApi.getIssueDetails(dispatch.issueId).catch(() => null);
+    const issue = {
+        id: dispatch.issueId,
+        identifier: dispatch.issueIdentifier,
+        title: issueDetails?.title ?? dispatch.issueIdentifier,
+        description: issueDetails?.description,
+    };
+    // Build worker prompt from YAML templates
+    // For multi-repo dispatches, render worktreePath as a list of repo→path mappings
+    const effectiveWorkerPath = dispatch.worktrees
+        ? dispatch.worktrees.map(w => `${w.repoName}: ${w.path}`).join("\n")
+        : dispatch.worktreePath;
+    // Look up cached guidance for the issue's team
+    const workerTeamId = issueDetails?.team?.id;
+    const workerTeamKey = issueDetails?.team?.key;
+    const workerGuidance = (workerTeamId && isGuidanceEnabled(pluginConfig, workerTeamId))
+        ? getCachedGuidanceForTeam(workerTeamId) ?? undefined
+        : undefined;
+    // Resolve team context from teamMappings config
+    const workerTeamMappings = pluginConfig?.teamMappings;
+    const workerTeamMapping = workerTeamKey ? workerTeamMappings?.[workerTeamKey] : undefined;
+    const workerTeamContext = workerTeamMapping?.context
+        ? `\n## Team Context (${workerTeamKey})\n${workerTeamMapping.context}\n`
+        : "";
+    const workerPrompt = buildWorkerTask(issue, effectiveWorkerPath, {
+        attempt: dispatch.attempt,
+        gaps: opts?.gaps,
+        pluginConfig,
+        guidance: workerGuidance,
+        teamContext: workerTeamContext,
+    });
+    const workerSessionId = `linear-worker-${dispatch.issueIdentifier}-${dispatch.attempt}`;
+    // Register session mapping for agent_end hook lookup
+    await registerSessionMapping(workerSessionId, {
+        dispatchId: dispatch.issueIdentifier,
+        phase: "worker",
+        attempt: dispatch.attempt,
+    }, configPath);
+    await hookCtx.notify("working", {
+        identifier: dispatch.issueIdentifier,
+        title: issue.title,
+        status: "working",
+        attempt: dispatch.attempt,
+    });
+    api.logger.info(`${TAG} spawning worker agent session=${workerSessionId} (attempt ${dispatch.attempt})`);
+    // Resolve agent: team mapping → plugin default
+    const defaultAgentId = pluginConfig?.defaultAgentId ?? "default";
+    let workerAgentId = defaultAgentId;
+    if (workerTeamKey) {
+        const teamDefault = workerTeamMappings?.[workerTeamKey]?.defaultAgent;
+        if (typeof teamDefault === "string") {
+            workerAgentId = teamDefault;
+            api.logger.info(`${TAG} worker agent routed to ${workerAgentId} via team mapping (${workerTeamKey})`);
+        }
+    }
+    // Mirror this phase into the openclaw task-flow registry. Best-effort —
+    // safe to call without checking for taskFlowId because the bridge no-ops
+    // when the runtime surface or flow state is missing.
+    recordPhaseTask(api, dispatch, "worker", workerAgentId, workerSessionId);
+    const workerStartTime = Date.now();
+    const result = await runAgent({
+        api,
+        agentId: workerAgentId,
+        sessionId: workerSessionId,
+        message: `${workerPrompt.system}\n\n${workerPrompt.task}`,
+        streaming: dispatch.agentSessionId
+            ? { linearApi, agentSessionId: dispatch.agentSessionId }
+            : undefined,
+    });
+    // Save worker output to .claw/
+    const workerElapsed = Date.now() - workerStartTime;
+    const agentId = workerAgentId;
+    try {
+        saveWorkerOutput(dispatch.worktreePath, dispatch.attempt, result.output);
+    }
+    catch { }
+    try {
+        appendLog(dispatch.worktreePath, {
+            ts: new Date().toISOString(), phase: "worker", attempt: dispatch.attempt,
+            agent: agentId,
+            prompt: workerPrompt.task.slice(0, 200),
+            outputPreview: result.output.slice(0, 500),
+            success: result.success, durationMs: workerElapsed,
+        });
+    }
+    catch { }
+    // Handle watchdog kill (runAgent already retried once — both attempts failed)
+    if (result.watchdogKilled) {
+        const wdConfig = resolveWatchdogConfig(agentId, pluginConfig ?? undefined);
+        const thresholdSec = Math.round(wdConfig.inactivityMs / 1000);
+        api.logger.warn(`${TAG} worker killed by inactivity watchdog 2x — escalating to stuck`);
+        emitDiagnostic(api, {
+            event: "watchdog_kill",
+            identifier: dispatch.issueIdentifier,
+            issueId: dispatch.issueId,
+            attempt: dispatch.attempt,
+            tier: dispatch.tier,
+            durationMs: workerElapsed,
+            agentId,
+        });
+        try {
+            appendLog(dispatch.worktreePath, {
+                ts: new Date().toISOString(), phase: "watchdog", attempt: dispatch.attempt,
+                agent: agentId, prompt: "(watchdog kill)",
+                outputPreview: result.output.slice(0, 500), success: false,
+                durationMs: workerElapsed,
+                watchdog: { reason: "inactivity", silenceSec: thresholdSec, thresholdSec, retried: true },
+            });
+        }
+        catch { }
+        try {
+            updateManifest(dispatch.worktreePath, { status: "stuck", attempts: dispatch.attempt + 1 });
+        }
+        catch { }
+        try {
+            await transitionDispatch(dispatch.issueIdentifier, "working", "stuck", { stuckReason: "watchdog_kill_2x" }, configPath);
+        }
+        catch (err) {
+            if (err instanceof TransitionError) {
+                api.logger.warn(`${TAG} CAS failed for watchdog stuck transition: ${err.message}`);
+            }
+        }
+        // Mirror watchdog-kill terminal into the openclaw task-flow registry.
+        markFlowTerminal(api, dispatch, "failed", `watchdog killed (no I/O for ${thresholdSec}s)`);
+        // Linear state transition: move to "Triage" so it shows up for human review
+        const wdIssueDetails = await linearApi.getIssueDetails(dispatch.issueId).catch(() => null);
+        await transitionLinearIssueState(linearApi, dispatch.issueId, wdIssueDetails?.team?.id, "triage", undefined, api.logger);
+        await linearApi.createComment(dispatch.issueId, `## Agent Timed Out\n\nThe agent stopped responding for over ${thresholdSec}s. It was automatically restarted, but the retry also timed out.\n\n` +
+            `**What you can do:**\n1. **Try again** — re-assign this issue or \`/dispatch retry ${dispatch.issueIdentifier}\`\n2. **Break it down** — if it keeps timing out, split into smaller issues\n3. **Increase timeout** — set \`inactivitySec\` higher in your agent profile\n\n` +
+            `**Logs:** \`${dispatch.worktreePath}/.claw/log.jsonl\` (look for \`"phase": "watchdog"\`)\n\n**Current status:** Stuck — waiting for you.`).catch(() => { });
+        await hookCtx.notify("watchdog_kill", {
+            identifier: dispatch.issueIdentifier,
+            title: issue.title,
+            status: "stuck",
+            attempt: dispatch.attempt,
+            reason: `no I/O for ${thresholdSec}s`,
+        });
+        clearActiveSession(dispatch.issueId);
+        return;
+    }
+    // runAgent returns inline — trigger audit directly.
+    // Re-read dispatch state since it may have changed during worker run.
+    const freshState = await readDispatchState(configPath);
+    const freshDispatch = getActiveDispatch(freshState, dispatch.issueIdentifier);
+    if (!freshDispatch) {
+        api.logger.warn(`${TAG} dispatch disappeared during worker run — skipping audit`);
+        return;
+    }
+    api.logger.info(`${TAG} worker completed (success=${result.success}, ${result.output.length} chars) — triggering audit`);
+    await triggerAudit(hookCtx, freshDispatch, {
+        success: result.success,
+        output: result.output,
+    }, workerSessionId);
+}

--- a/dist/src/pipeline/planner.js
+++ b/dist/src/pipeline/planner.js
@@ -1,0 +1,233 @@
+import { loadRawPromptYaml } from "./pipeline.js";
+import { runAgent } from "../agent/agent.js";
+import { registerPlanningSession, updatePlanningSession, setPlanningCache, } from "./planning-state.js";
+import { setActivePlannerContext, clearActivePlannerContext, buildPlanSnapshot, auditPlan, } from "../tools/planner-tools.js";
+import { runClaude } from "../tools/claude-tool.js";
+import { runCodex } from "../tools/codex-tool.js";
+import { runGemini } from "../tools/gemini-tool.js";
+import { renderTemplate } from "../infra/template.js";
+// ---------------------------------------------------------------------------
+// Prompt loading
+// ---------------------------------------------------------------------------
+function loadPlannerPrompts(pluginConfig) {
+    const defaults = {
+        system: "You are a product planning specialist. Interview the user about features and create Linear issues.",
+        interview: "Project: {{projectName}}\n\nPlan:\n{{planSnapshot}}\n\nUser said: {{userMessage}}\n\nContinue planning.",
+        audit_prompt: "Run audit_plan for {{projectName}}.",
+        welcome: "Entering planning mode for **{{projectName}}**. What are the main feature areas?",
+        review: "Plan for {{projectName}} passed checks. {{reviewModel}} recommends:\n{{crossModelFeedback}}\n\nReview and suggest changes, then invite the user to approve.",
+    };
+    const parsed = loadRawPromptYaml(pluginConfig);
+    if (parsed?.planner) {
+        return {
+            system: parsed.planner.system ?? defaults.system,
+            interview: parsed.planner.interview ?? defaults.interview,
+            audit_prompt: parsed.planner.audit_prompt ?? defaults.audit_prompt,
+            welcome: parsed.planner.welcome ?? defaults.welcome,
+            review: parsed.planner.review ?? defaults.review,
+        };
+    }
+    return defaults;
+}
+// ---------------------------------------------------------------------------
+// Planning initiation
+// ---------------------------------------------------------------------------
+export async function initiatePlanningSession(ctx, projectId, rootIssue) {
+    const { api, linearApi, pluginConfig } = ctx;
+    const configPath = pluginConfig?.planningStatePath;
+    // Fetch project metadata
+    const project = await linearApi.getProject(projectId);
+    const teamId = rootIssue.team?.id ?? project.teams?.nodes?.[0]?.id;
+    if (!teamId)
+        throw new Error(`Cannot determine team for project ${projectId}`);
+    // Fetch team states for reference
+    await linearApi.getTeamStates(teamId);
+    // Register session
+    const session = {
+        projectId,
+        projectName: project.name,
+        rootIssueId: rootIssue.id,
+        rootIdentifier: rootIssue.identifier,
+        teamId,
+        status: "interviewing",
+        startedAt: new Date().toISOString(),
+        turnCount: 0,
+    };
+    await registerPlanningSession(projectId, session, configPath);
+    setPlanningCache(session);
+    api.logger.info(`Planning: initiated session for ${project.name} (${rootIssue.identifier})`);
+    // Post welcome comment
+    const prompts = loadPlannerPrompts(pluginConfig);
+    const welcomeMsg = renderTemplate(prompts.welcome, {
+        projectName: project.name,
+        rootIdentifier: rootIssue.identifier,
+    });
+    await linearApi.createComment(rootIssue.id, welcomeMsg);
+}
+// ---------------------------------------------------------------------------
+// Interview turn
+// ---------------------------------------------------------------------------
+/**
+ * Handle a planning conversation turn. Intent detection (finalize/abandon)
+ * is handled by the webhook via intent-classify.ts before calling this function.
+ * This is a pure "continue planning" function.
+ */
+export async function handlePlannerTurn(ctx, session, input) {
+    const { api, linearApi, pluginConfig } = ctx;
+    const configPath = pluginConfig?.planningStatePath;
+    // Increment turn count
+    const newTurnCount = session.turnCount + 1;
+    await updatePlanningSession(session.projectId, { turnCount: newTurnCount }, configPath);
+    // Build plan snapshot
+    const issues = await linearApi.getProjectIssues(session.projectId);
+    const planSnapshot = buildPlanSnapshot(issues);
+    // Build comment history (last 10 comments on root issue)
+    let commentHistory = "";
+    try {
+        const details = await linearApi.getIssueDetails(session.rootIssueId);
+        commentHistory = details.comments?.nodes
+            ?.map((c) => `**${c.user?.name ?? "Unknown"}:** ${c.body.slice(0, 300)}`)
+            .join("\n\n") ?? "";
+    }
+    catch { /* best effort */ }
+    // Build prompt
+    const prompts = loadPlannerPrompts(pluginConfig);
+    const taskPrompt = renderTemplate(prompts.interview, {
+        projectName: session.projectName,
+        rootIdentifier: session.rootIdentifier,
+        planSnapshot,
+        turnCount: String(newTurnCount),
+        commentHistory,
+        userMessage: input.commentBody,
+    });
+    // Set planner context for tools
+    setActivePlannerContext({
+        linearApi,
+        projectId: session.projectId,
+        teamId: session.teamId,
+        api,
+        pluginConfig,
+    });
+    try {
+        const sessionId = `planner-${session.rootIdentifier}-turn-${newTurnCount}`;
+        const agentId = pluginConfig?.defaultAgentId ?? "default";
+        api.logger.info(`Planning: turn ${newTurnCount} for ${session.projectName}`);
+        const result = await runAgent({
+            api,
+            agentId,
+            sessionId,
+            message: `${prompts.system}\n\n${taskPrompt}`,
+        });
+        // Post agent response as comment
+        if (result.output) {
+            await linearApi.createComment(session.rootIssueId, result.output);
+        }
+    }
+    finally {
+        clearActivePlannerContext();
+    }
+}
+// ---------------------------------------------------------------------------
+// Plan audit
+// ---------------------------------------------------------------------------
+export async function runPlanAudit(ctx, session) {
+    const { api, linearApi, pluginConfig } = ctx;
+    const configPath = pluginConfig?.planningStatePath;
+    api.logger.info(`Planning: running audit for ${session.projectName}`);
+    // Run deterministic audit
+    const issues = await linearApi.getProjectIssues(session.projectId);
+    const result = auditPlan(issues);
+    if (result.pass) {
+        // Transition to plan_review (not approved yet — cross-model review first)
+        await updatePlanningSession(session.projectId, { status: "plan_review" }, configPath);
+        const snapshot = buildPlanSnapshot(issues);
+        const warningsList = result.warnings.length > 0
+            ? `\n\n**Warnings:**\n${result.warnings.map((w) => `- ${w}`).join("\n")}`
+            : "";
+        // Determine review model and post "running review" message
+        const reviewModel = resolveReviewModel(pluginConfig);
+        const reviewModelName = reviewModel.charAt(0).toUpperCase() + reviewModel.slice(1);
+        await linearApi.createComment(session.rootIssueId, `## Plan Passed Checks\n\n` +
+            `**${issues.length} issues** with valid dependency graph.${warningsList}\n\n` +
+            `Let me have **${reviewModelName}** audit this and make recommendations.`);
+        // Run cross-model review
+        const crossReview = await runCrossModelReview(api, reviewModel, snapshot, pluginConfig);
+        // Run planner agent with review prompt + cross-model feedback
+        const prompts = loadPlannerPrompts(pluginConfig);
+        const reviewPrompt = renderTemplate(prompts.review, {
+            projectName: session.projectName,
+            planSnapshot: snapshot,
+            issueCount: String(issues.length),
+            reviewModel: reviewModelName,
+            crossModelFeedback: crossReview,
+        });
+        const agentId = pluginConfig?.defaultAgentId ?? "default";
+        setActivePlannerContext({
+            linearApi,
+            projectId: session.projectId,
+            teamId: session.teamId,
+            api,
+            pluginConfig,
+        });
+        try {
+            const agentResult = await runAgent({
+                api,
+                agentId,
+                sessionId: `planner-${session.rootIdentifier}-review`,
+                message: `${prompts.system}\n\n${reviewPrompt}`,
+            });
+            if (agentResult.output) {
+                await linearApi.createComment(session.rootIssueId, agentResult.output);
+            }
+        }
+        finally {
+            clearActivePlannerContext();
+        }
+        api.logger.info(`Planning: entered plan_review for ${session.projectName} (reviewed by ${reviewModelName})`);
+    }
+    else {
+        // Post problems and keep planning
+        const problemsList = result.problems.map((p) => `- ${p}`).join("\n");
+        const warningsList = result.warnings.length > 0
+            ? `\n\n**Warnings:**\n${result.warnings.map((w) => `- ${w}`).join("\n")}`
+            : "";
+        await linearApi.createComment(session.rootIssueId, `## Plan Audit Failed\n\n` +
+            `The following issues need attention before the plan can be approved:\n\n` +
+            `**Problems:**\n${problemsList}${warningsList}\n\n` +
+            `Please address these issues, then say "finalize plan" again.`);
+        api.logger.info(`Planning: audit failed for ${session.projectName} (${result.problems.length} problems)`);
+    }
+}
+// ---------------------------------------------------------------------------
+// Cross-model review
+// ---------------------------------------------------------------------------
+export async function runCrossModelReview(api, model, planSnapshot, pluginConfig) {
+    const prompt = `You are reviewing a project plan. Analyze it and suggest specific improvements.\n\n${planSnapshot}\n\nFocus on: missing acceptance criteria, dependency gaps, estimation accuracy, testability, and edge cases. Reference specific issue identifiers. Be concise and actionable.`;
+    try {
+        const runner = model === "claude" ? runClaude
+            : model === "codex" ? runCodex
+                : runGemini;
+        const result = await runner(api, { prompt }, pluginConfig);
+        return result.success ? (result.output ?? "(no feedback)") : `(${model} review failed: ${result.error})`;
+    }
+    catch (err) {
+        api.logger.warn(`Cross-model review failed: ${err}`);
+        return "(cross-model review unavailable)";
+    }
+}
+export function resolveReviewModel(pluginConfig) {
+    // User override in config
+    const configured = pluginConfig?.plannerReviewModel;
+    if (configured && ["claude", "codex", "gemini"].includes(configured)) {
+        return configured;
+    }
+    // Always the complement of the user's primary model
+    const currentModel = pluginConfig?.agents?.defaults?.model?.primary ?? "";
+    if (currentModel.includes("claude") || currentModel.includes("anthropic"))
+        return "codex";
+    if (currentModel.includes("codex") || currentModel.includes("openai"))
+        return "gemini";
+    if (currentModel.includes("gemini") || currentModel.includes("google"))
+        return "codex";
+    return "gemini"; // Kimi, Mistral, other, or unconfigured → Gemini reviews
+}

--- a/dist/src/pipeline/planning-state.js
+++ b/dist/src/pipeline/planning-state.js
@@ -1,0 +1,141 @@
+/**
+ * planning-state.ts — File-backed persistent planning session state.
+ *
+ * Tracks active planning sessions across gateway restarts.
+ * Uses file-level locking to prevent concurrent read-modify-write races.
+ * Mirrors the dispatch-state.ts pattern.
+ */
+import fs from "node:fs/promises";
+import { existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+const DEFAULT_STATE_PATH = path.join(homedir(), ".openclaw", "linear-planning-state.json");
+const MAX_PROCESSED_EVENTS = 200;
+function resolveStatePath(configPath) {
+    if (!configPath)
+        return DEFAULT_STATE_PATH;
+    if (configPath.startsWith("~/"))
+        return configPath.replace("~", homedir());
+    return configPath;
+}
+// ---------------------------------------------------------------------------
+// File locking (shared utility)
+// ---------------------------------------------------------------------------
+import { acquireLock, releaseLock } from "../infra/file-lock.js";
+// ---------------------------------------------------------------------------
+// Read / Write
+// ---------------------------------------------------------------------------
+function emptyState() {
+    return { sessions: {}, processedEvents: [] };
+}
+export async function readPlanningState(configPath) {
+    const filePath = resolveStatePath(configPath);
+    try {
+        const raw = await fs.readFile(filePath, "utf-8");
+        const parsed = JSON.parse(raw);
+        if (!parsed.sessions)
+            parsed.sessions = {};
+        if (!parsed.processedEvents)
+            parsed.processedEvents = [];
+        return parsed;
+    }
+    catch (err) {
+        if (err.code === "ENOENT")
+            return emptyState();
+        if (err instanceof SyntaxError) {
+            // State file corrupted — log and recover
+            console.error(`Planning state corrupted at ${filePath}: ${err.message}. Starting fresh.`);
+            // Rename corrupted file for forensics
+            try {
+                await fs.rename(filePath, `${filePath}.corrupted.${Date.now()}`);
+            }
+            catch { /* best-effort */ }
+            return emptyState();
+        }
+        throw err;
+    }
+}
+export async function writePlanningState(data, configPath) {
+    const filePath = resolveStatePath(configPath);
+    const dir = path.dirname(filePath);
+    if (!existsSync(dir))
+        mkdirSync(dir, { recursive: true });
+    if (data.processedEvents.length > MAX_PROCESSED_EVENTS) {
+        data.processedEvents = data.processedEvents.slice(-MAX_PROCESSED_EVENTS);
+    }
+    const tmpPath = filePath + ".tmp";
+    await fs.writeFile(tmpPath, JSON.stringify(data, null, 2) + "\n", "utf-8");
+    await fs.rename(tmpPath, filePath);
+}
+// ---------------------------------------------------------------------------
+// Session operations
+// ---------------------------------------------------------------------------
+export async function registerPlanningSession(projectId, session, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readPlanningState(configPath);
+        data.sessions[projectId] = session;
+        await writePlanningState(data, configPath);
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+export async function updatePlanningSession(projectId, updates, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readPlanningState(configPath);
+        const session = data.sessions[projectId];
+        if (!session)
+            throw new Error(`No planning session for project ${projectId}`);
+        Object.assign(session, updates);
+        await writePlanningState(data, configPath);
+        return session;
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+export function getPlanningSession(state, projectId) {
+    return state.sessions[projectId] ?? null;
+}
+export async function endPlanningSession(projectId, status, configPath) {
+    const filePath = resolveStatePath(configPath);
+    await acquireLock(filePath);
+    try {
+        const data = await readPlanningState(configPath);
+        const session = data.sessions[projectId];
+        if (session) {
+            session.status = status;
+            await writePlanningState(data, configPath);
+        }
+        clearPlanningCache(projectId);
+    }
+    finally {
+        await releaseLock(filePath);
+    }
+}
+export function isInPlanningMode(state, projectId) {
+    const session = state.sessions[projectId];
+    if (!session)
+        return false;
+    return session.status === "interviewing" || session.status === "plan_review";
+}
+// ---------------------------------------------------------------------------
+// In-memory cache for fast webhook routing
+// ---------------------------------------------------------------------------
+const planningCache = new Map();
+export function setPlanningCache(session) {
+    planningCache.set(session.projectId, session);
+}
+export function clearPlanningCache(projectId) {
+    planningCache.delete(projectId);
+}
+export function getActivePlanningByProjectId(projectId) {
+    return planningCache.get(projectId) ?? null;
+}

--- a/dist/src/pipeline/taskflow-bridge.js
+++ b/dist/src/pipeline/taskflow-bridge.js
@@ -1,0 +1,246 @@
+/**
+ * taskflow-bridge.ts — Bridge between the plugin's dispatch-state lifecycle
+ * and OpenClaw 2026.4's first-class durable task-flow runtime.
+ *
+ * OpenClaw 2026.4 added `api.runtime.taskFlow` — a durable, restart-safe task
+ * registry with `createManaged`, `runTask`, `setWaiting`, `finish`, `fail`,
+ * and `requestCancel` operations. The Linear plugin already keeps its own
+ * dispatch-state for tier/issueId/webhook attempt tracking; this bridge
+ * mirrors that lifecycle into the openclaw task registry so dispatches show
+ * up in any task-aware UI/CLI without us discarding the Linear-specific
+ * metadata that doesn't map cleanly onto TaskRunView.
+ *
+ * Design choices:
+ *
+ *   • Best-effort. Every call is wrapped in try/catch. If the runtime
+ *     surface is missing (older openclaw, test fakes, or the API gets
+ *     renamed in a future release) the plugin keeps working — the bridge
+ *     logs at debug and the dispatch proceeds without a flow record.
+ *
+ *   • Stateless from the bridge's perspective. The flowId and the latest
+ *     observed revision are stored back into ActiveDispatch so all callers
+ *     can resume mutations from whatever the file lock last persisted.
+ *
+ *   • Phase mapping:
+ *       dispatch     → createManaged({ goal: "Resolve <ID>: <title>" })
+ *       working      → runTask({ task: "worker", status: "running" })
+ *       auditing     → runTask({ task: "audit", status: "running" })
+ *       stuck/rework → setWaiting({ blockedSummary })
+ *       done         → finish({})
+ *       failed       → fail({ blockedSummary })
+ *
+ *   • Identifier convention: controllerId is `linear-dispatch:<issueIdentifier>`
+ *     so tasks created across dispatches stay correlated to a single Linear
+ *     issue even after retries.
+ */
+const CONTROLLER_PREFIX = "linear-dispatch";
+/**
+ * Locate the managed task-flow mutation API across OpenClaw SDK versions.
+ */
+function resolveTaskFlowApi(api) {
+    const runtime = api.runtime;
+    if (!runtime)
+        return null;
+    const tasks = runtime.tasks;
+    for (const candidate of [tasks?.managedFlows, tasks?.flow, runtime.taskFlow]) {
+        if (candidate && typeof candidate.bindSession === "function") {
+            return candidate;
+        }
+    }
+    return null;
+}
+/**
+ * Bind the task-flow API to the session that owns the Linear dispatch.
+ */
+function bindFlow(api, sessionKey) {
+    const taskFlow = resolveTaskFlowApi(api);
+    if (!taskFlow)
+        return null;
+    try {
+        return taskFlow.bindSession({ sessionKey });
+    }
+    catch (err) {
+        api.logger.debug?.(`taskflow-bridge: bindSession failed: ${formatErr(err)}`);
+        return null;
+    }
+}
+/**
+ * Normalize thrown values for debug logging without leaking stack traces.
+ */
+function formatErr(err) {
+    return err instanceof Error ? err.message : String(err);
+}
+/**
+ * Build the stable OpenClaw controller identifier for a Linear issue.
+ */
+function controllerIdFor(dispatch) {
+    return `${CONTROLLER_PREFIX}:${dispatch.issueIdentifier}`;
+}
+/**
+ * Build the task-flow goal shown in OpenClaw task views.
+ */
+function goalFor(dispatch) {
+    const title = dispatch.issueTitle ?? "(no title)";
+    return `Resolve ${dispatch.issueIdentifier}: ${title}`;
+}
+/**
+ * Resolve a session key to bind the managed flow under. We prefer the
+ * worker session key (set when the agent is dispatched) and fall back to
+ * a synthetic key per issue so the bridge still works when the worker
+ * hasn't started yet.
+ */
+function sessionKeyFor(dispatch) {
+    return (dispatch.workerSessionKey ??
+        dispatch.auditSessionKey ??
+        `linear:dispatch:${dispatch.issueIdentifier}`);
+}
+// ---------------------------------------------------------------------------
+// Lifecycle helpers
+// ---------------------------------------------------------------------------
+/**
+ * Create a managed task flow for a freshly registered dispatch and return
+ * the patched ActiveDispatch (with `taskFlowId` + `taskFlowRevision` set).
+ *
+ * Returns the original dispatch unchanged when the runtime surface is
+ * unavailable. Never throws — bridge failures are logged at debug level.
+ */
+export function createManagedFlowForDispatch(api, dispatch) {
+    const flow = bindFlow(api, sessionKeyFor(dispatch));
+    if (!flow)
+        return dispatch;
+    try {
+        const created = flow.createManaged({
+            controllerId: controllerIdFor(dispatch),
+            goal: goalFor(dispatch),
+            currentStep: "dispatched",
+        });
+        api.logger.info(`taskflow-bridge: created managed flow ${created.id} for ${dispatch.issueIdentifier} ` +
+            `(controller=${controllerIdFor(dispatch)})`);
+        return {
+            ...dispatch,
+            taskFlowId: created.id,
+            taskFlowRevision: created.revision,
+        };
+    }
+    catch (err) {
+        api.logger.debug?.(`taskflow-bridge: createManaged failed for ${dispatch.issueIdentifier}: ${formatErr(err)}`);
+        return dispatch;
+    }
+}
+/**
+ * Record a child task for a dispatch phase ("worker" / "audit"). The flow
+ * runtime will then track that child via the gateway's task registry.
+ */
+export function recordPhaseTask(api, dispatch, phase, agentId, childSessionKey) {
+    if (!dispatch.taskFlowId)
+        return;
+    const flow = bindFlow(api, sessionKeyFor(dispatch));
+    if (!flow)
+        return;
+    try {
+        flow.runTask({
+            flowId: dispatch.taskFlowId,
+            // `runtime: "subagent"` is the closest valid TaskRuntime value for
+            // our embedded-agent-via-runEmbeddedPiAgent path. The runtime's
+            // auto-settlement (subagent-registry → completeTaskRunByRunId) keys
+            // off `(runtime, runId, childSessionKey)`. We don't currently
+            // register with subagent-registry, so per-task auto-settlement won't
+            // fire — but the FLOW-level finish/fail in `markFlowTerminal`
+            // cascades the in-progress tasks regardless, which is what we care
+            // about for dispatch observability.
+            runtime: "subagent",
+            task: phase,
+            status: "running",
+            agentId,
+            childSessionKey,
+            label: `${dispatch.issueIdentifier} ${phase} (attempt ${dispatch.attempt + 1})`,
+            progressSummary: `attempt ${dispatch.attempt + 1}`,
+        });
+    }
+    catch (err) {
+        api.logger.debug?.(`taskflow-bridge: runTask(${phase}) failed for ${dispatch.issueIdentifier}: ${formatErr(err)}`);
+    }
+}
+/**
+ * Mark the flow as waiting (between phases, or stuck on user input).
+ */
+export function markFlowWaiting(api, dispatch, step, blockedSummary) {
+    if (!dispatch.taskFlowId || dispatch.taskFlowRevision == null)
+        return dispatch;
+    const flow = bindFlow(api, sessionKeyFor(dispatch));
+    if (!flow)
+        return dispatch;
+    try {
+        const result = flow.setWaiting({
+            flowId: dispatch.taskFlowId,
+            expectedRevision: dispatch.taskFlowRevision,
+            currentStep: step,
+            blockedSummary,
+        });
+        if (result.applied && result.flow) {
+            return { ...dispatch, taskFlowRevision: result.flow.revision };
+        }
+    }
+    catch (err) {
+        api.logger.debug?.(`taskflow-bridge: setWaiting failed for ${dispatch.issueIdentifier}: ${formatErr(err)}`);
+    }
+    return dispatch;
+}
+/**
+ * Resume the flow into a running phase (used after rework / re-dispatch).
+ */
+export function markFlowResumed(api, dispatch, step) {
+    if (!dispatch.taskFlowId || dispatch.taskFlowRevision == null)
+        return dispatch;
+    const flow = bindFlow(api, sessionKeyFor(dispatch));
+    if (!flow)
+        return dispatch;
+    try {
+        const result = flow.resume({
+            flowId: dispatch.taskFlowId,
+            expectedRevision: dispatch.taskFlowRevision,
+            status: "running",
+            currentStep: step,
+        });
+        if (result.applied && result.flow) {
+            return { ...dispatch, taskFlowRevision: result.flow.revision };
+        }
+    }
+    catch (err) {
+        api.logger.debug?.(`taskflow-bridge: resume failed for ${dispatch.issueIdentifier}: ${formatErr(err)}`);
+    }
+    return dispatch;
+}
+/**
+ * Terminal: finish (success) or fail (with a summary).
+ */
+export function markFlowTerminal(api, dispatch, outcome, reason) {
+    if (!dispatch.taskFlowId || dispatch.taskFlowRevision == null)
+        return;
+    const flow = bindFlow(api, sessionKeyFor(dispatch));
+    if (!flow)
+        return;
+    try {
+        if (outcome === "done") {
+            flow.finish({
+                flowId: dispatch.taskFlowId,
+                expectedRevision: dispatch.taskFlowRevision,
+                endedAt: Date.now(),
+            });
+        }
+        else {
+            flow.fail({
+                flowId: dispatch.taskFlowId,
+                expectedRevision: dispatch.taskFlowRevision,
+                blockedSummary: reason,
+                endedAt: Date.now(),
+            });
+        }
+        api.logger.info(`taskflow-bridge: ${outcome === "done" ? "finished" : "failed"} flow ` +
+            `${dispatch.taskFlowId} for ${dispatch.issueIdentifier}` +
+            (reason ? ` (${reason})` : ""));
+    }
+    catch (err) {
+        api.logger.debug?.(`taskflow-bridge: ${outcome} failed for ${dispatch.issueIdentifier}: ${formatErr(err)}`);
+    }
+}

--- a/dist/src/pipeline/tier-assess.js
+++ b/dist/src/pipeline/tier-assess.js
@@ -1,0 +1,101 @@
+import { resolveDefaultAgent } from "../infra/shared-profiles.js";
+// ---------------------------------------------------------------------------
+// Tier → Model mapping
+// ---------------------------------------------------------------------------
+export const TIER_MODELS = {
+    small: "anthropic/claude-haiku-4-5",
+    medium: "anthropic/claude-sonnet-4-6",
+    high: "anthropic/claude-opus-4-6",
+};
+// ---------------------------------------------------------------------------
+// Assessment
+// ---------------------------------------------------------------------------
+const ASSESS_PROMPT = `You are a complexity assessor. Assess this issue and respond ONLY with JSON.
+
+Tiers:
+- small: typos, copy changes, config tweaks, simple CSS, env var additions
+- medium: features, bugfixes, moderate refactoring, adding tests, API changes
+- high: architecture changes, database migrations, security fixes, multi-service coordination
+
+Consider:
+1. How many files/services are likely affected?
+2. Does it touch auth, data, or external APIs? (higher risk → higher tier)
+3. Is the description clear and actionable?
+4. Are there dependencies or unknowns?
+
+Respond ONLY with: {"tier":"small|medium|high","reasoning":"one sentence"}`;
+/**
+ * Assess issue complexity using the agent's configured model.
+ *
+ * Falls back to "medium" if the agent call fails or returns invalid JSON.
+ */
+export async function assessTier(api, issue, agentId) {
+    const issueText = [
+        `Issue: ${issue.identifier} — ${issue.title}`,
+        issue.description ? `Description: ${issue.description.slice(0, 1500)}` : "",
+        issue.labels?.length ? `Labels: ${issue.labels.join(", ")}` : "",
+        issue.commentCount != null ? `Comments: ${issue.commentCount}` : "",
+    ].filter(Boolean).join("\n");
+    const message = `${ASSESS_PROMPT}\n\n${issueText}`;
+    try {
+        const { runAgent } = await import("../agent/agent.js");
+        const result = await runAgent({
+            api,
+            agentId: agentId ?? resolveDefaultAgent(api),
+            sessionId: `tier-assess-${issue.identifier}-${Date.now()}`,
+            message,
+            timeoutMs: 30_000, // 30s — this should be fast
+        });
+        // Try to parse assessment from output regardless of success flag.
+        // runAgent may report success:false (non-zero exit code) even when
+        // the agent produced valid JSON output — e.g. agent exited with
+        // signal but wrote the response before terminating.
+        if (result.output) {
+            const parsed = parseAssessment(result.output);
+            if (parsed) {
+                api.logger.info(`Tier assessment for ${issue.identifier}: ${parsed.tier} — ${parsed.reasoning} (agent success=${result.success})`);
+                return parsed;
+            }
+        }
+        if (!result.success) {
+            api.logger.warn(`Tier assessment agent failed for ${issue.identifier}: ${result.output.slice(0, 200)}`);
+        }
+        else {
+            api.logger.warn(`Tier assessment for ${issue.identifier}: could not parse response: ${result.output.slice(0, 200)}`);
+        }
+    }
+    catch (err) {
+        api.logger.warn(`Tier assessment error for ${issue.identifier}: ${err}`);
+    }
+    // Fallback: medium is the safest default
+    const fallback = {
+        tier: "medium",
+        model: TIER_MODELS.medium,
+        reasoning: "Assessment failed — defaulting to medium",
+    };
+    api.logger.info(`Tier assessment fallback for ${issue.identifier}: medium`);
+    return fallback;
+}
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function parseAssessment(raw) {
+    // Extract JSON from the response (may have markdown wrapping)
+    const jsonMatch = raw.match(/\{[^}]+\}/);
+    if (!jsonMatch)
+        return null;
+    try {
+        const parsed = JSON.parse(jsonMatch[0]);
+        const tier = parsed.tier;
+        if (tier !== "small" && tier !== "medium" && tier !== "high")
+            return null;
+        return {
+            tier: tier,
+            model: TIER_MODELS[tier],
+            reasoning: parsed.reasoning ?? "no reasoning provided",
+        };
+    }
+    catch {
+        return null;
+    }
+}

--- a/dist/src/pipeline/webhook.js
+++ b/dist/src/pipeline/webhook.js
@@ -1,0 +1,2154 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { LinearAgentApi, resolveLinearToken } from "../api/linear-api.js";
+import { spawnWorker, buildProjectContext } from "./pipeline.js";
+import { setActiveSession, clearActiveSession, getIssueAffinity, _resetAffinityForTesting } from "./active-session.js";
+import { readDispatchState, getActiveDispatch, registerDispatch, updateDispatchStatus, removeActiveDispatch } from "./dispatch-state.js";
+import { createManagedFlowForDispatch } from "./taskflow-bridge.js";
+import { createNotifierFromConfig } from "../infra/notify.js";
+import { assessTier } from "./tier-assess.js";
+import { createWorktree, createMultiWorktree, prepareWorkspace } from "../infra/codex-worktree.js";
+import { resolveRepos, isMultiRepo } from "../infra/multi-repo.js";
+import { ensureClawDir, writeManifest, writeDispatchMemory, resolveOrchestratorWorkspace } from "./artifacts.js";
+import { readPlanningState, isInPlanningMode, getPlanningSession, endPlanningSession } from "./planning-state.js";
+import { initiatePlanningSession, handlePlannerTurn, runPlanAudit } from "./planner.js";
+import { startProjectDispatch } from "./dag-dispatch.js";
+import { emitDiagnostic } from "../infra/observability.js";
+import { classifyIntent } from "./intent-classify.js";
+import { extractGuidance, formatGuidanceAppendix, cacheGuidanceForTeam, getCachedGuidanceForTeam, isGuidanceEnabled, _resetGuidanceCacheForTesting } from "./guidance.js";
+import { loadAgentProfiles, buildMentionPattern, resolveAgentFromAlias, validateProfiles, _resetProfilesCacheForTesting } from "../infra/shared-profiles.js";
+import { getActiveTmuxSession } from "../infra/tmux-runner.js";
+import { capturePane } from "../infra/tmux.js";
+import { loadCodingConfig, resolveToolName } from "../tools/code-tool.js";
+// ── Prompt input sanitization ─────────────────────────────────────
+/**
+ * Sanitize user-controlled text before embedding in agent prompts.
+ * Prevents token budget abuse (truncation) and template variable
+ * injection (escaping {{ / }}).
+ */
+export function sanitizePromptInput(text, maxLength = 4000) {
+    if (!text)
+        return "(no content)";
+    // Truncate to prevent token budget abuse
+    let sanitized = text.slice(0, maxLength);
+    // Escape template variable patterns that could interfere with prompt processing
+    sanitized = sanitized.replace(/\{\{/g, "{ {").replace(/\}\}/g, "} }");
+    return sanitized;
+}
+/**
+ * Check if a work request should be blocked based on issue state.
+ * Returns a rejection message if blocked, null if allowed.
+ */
+function shouldBlockWorkRequest(intent, stateType, stateName, issueRef) {
+    if (intent !== "request_work")
+        return null;
+    if (stateType === "started")
+        return null; // In Progress — allow
+    return (`This issue (${issueRef}) is in **${stateName}** — it needs planning and scoping before implementation.\n\n` +
+        `**To move forward:**\n` +
+        `1. Update the issue description with requirements and acceptance criteria\n` +
+        `2. Move the issue to **In Progress**\n` +
+        `3. Then ask me to implement it\n\n` +
+        `I can help you scope and plan — just ask questions or discuss the approach.`);
+}
+// Track issues with active agent runs to prevent concurrent duplicate runs.
+const activeRuns = new Set();
+// Dedup: track recently processed keys to avoid double-handling.
+// Periodic sweep instead of O(n) scan on every call.
+// TTLs are configurable via pluginConfig (dedupTtlMs, dedupSweepIntervalMs).
+const recentlyProcessed = new Map();
+let _dedupTtlMs = 60_000;
+let _sweepIntervalMs = 10_000;
+let lastSweep = Date.now();
+/** @internal — configure dedup TTLs from pluginConfig. Called once at module init or from tests. */
+export function _configureDedupTtls(pluginConfig) {
+    _dedupTtlMs = pluginConfig?.dedupTtlMs ?? 60_000;
+    _sweepIntervalMs = pluginConfig?.dedupSweepIntervalMs ?? 10_000;
+}
+/** @internal — read current dedup TTL (for testing). */
+export function _getDedupTtlMs() {
+    return _dedupTtlMs;
+}
+function wasRecentlyProcessed(key) {
+    const now = Date.now();
+    if (now - lastSweep > _sweepIntervalMs) {
+        for (const [k, ts] of recentlyProcessed) {
+            if (now - ts > _dedupTtlMs)
+                recentlyProcessed.delete(k);
+        }
+        lastSweep = now;
+    }
+    if (recentlyProcessed.has(key))
+        return true;
+    recentlyProcessed.set(key, now);
+    return false;
+}
+/** @internal — test-only; clears all in-memory dedup state. */
+export function _resetForTesting() {
+    activeRuns.clear();
+    recentlyProcessed.clear();
+    recentlyEmittedActivities.clear();
+    _resetProfilesCacheForTesting();
+    linearApiCache = null;
+    lastSweep = Date.now();
+    _dedupTtlMs = 60_000;
+    _sweepIntervalMs = 10_000;
+    _resetGuidanceCacheForTesting();
+    _resetAffinityForTesting();
+}
+// ── Feedback loop prevention for steering ─────────────────────────────
+// Track recently emitted activity body hashes to prevent our own emissions
+// from triggering the steering handler.
+const recentlyEmittedActivities = new Map();
+const EMITTED_TTL_MS = 30_000;
+function hashActivityBody(body) {
+    // Simple fast hash — not crypto, just dedup
+    let hash = 0;
+    for (let i = 0; i < Math.min(body.length, 200); i++) {
+        hash = ((hash << 5) - hash + body.charCodeAt(i)) | 0;
+    }
+    return String(hash);
+}
+export function trackEmittedActivity(body) {
+    const hash = hashActivityBody(body);
+    recentlyEmittedActivities.set(hash, Date.now());
+    // Prune entries older than TTL
+    const now = Date.now();
+    for (const [k, ts] of recentlyEmittedActivities) {
+        if (now - ts > EMITTED_TTL_MS)
+            recentlyEmittedActivities.delete(k);
+    }
+}
+function wasRecentlyEmitted(body) {
+    const hash = hashActivityBody(body);
+    return recentlyEmittedActivities.has(hash);
+}
+/** @internal — test-only; add an issue ID to the activeRuns set. */
+export function _addActiveRunForTesting(issueId) {
+    activeRuns.add(issueId);
+}
+/** @internal — test-only; pre-registers a key as recently processed. */
+export function _markAsProcessedForTesting(key) {
+    wasRecentlyProcessed(key);
+}
+/** @internal — exported for testing */
+export async function readJsonBody(req, maxBytes, timeoutMs = 5000) {
+    const chunks = [];
+    let total = 0;
+    let settled = false;
+    return await new Promise((resolve) => {
+        const timer = setTimeout(() => {
+            if (settled)
+                return;
+            settled = true;
+            req.destroy();
+            resolve({ ok: false, error: "Request body timeout" });
+        }, timeoutMs);
+        req.on("data", (chunk) => {
+            if (settled)
+                return;
+            total += chunk.length;
+            if (total > maxBytes) {
+                settled = true;
+                clearTimeout(timer);
+                req.destroy();
+                resolve({ ok: false, error: "payload too large" });
+                return;
+            }
+            chunks.push(chunk);
+        });
+        req.on("end", () => {
+            if (settled)
+                return;
+            settled = true;
+            clearTimeout(timer);
+            try {
+                const raw = Buffer.concat(chunks).toString("utf8");
+                resolve({ ok: true, value: JSON.parse(raw) });
+            }
+            catch {
+                resolve({ ok: false, error: "invalid json" });
+            }
+        });
+        req.on("error", () => {
+            if (settled)
+                return;
+            settled = true;
+            clearTimeout(timer);
+            resolve({ ok: false, error: "request error" });
+        });
+    });
+}
+// ── Cached LinearApi instance (30s TTL) ────────────────────────────
+let linearApiCache = null;
+const LINEAR_API_CACHE_TTL_MS = 30_000;
+function createLinearApi(api) {
+    const now = Date.now();
+    if (linearApiCache && now - linearApiCache.createdAt < LINEAR_API_CACHE_TTL_MS) {
+        return linearApiCache.instance;
+    }
+    const pluginConfig = api.pluginConfig;
+    const resolved = resolveLinearToken(pluginConfig);
+    if (!resolved.accessToken)
+        return null;
+    const clientId = pluginConfig?.clientId ?? process.env.LINEAR_CLIENT_ID;
+    const clientSecret = pluginConfig?.clientSecret ?? process.env.LINEAR_CLIENT_SECRET;
+    const instance = new LinearAgentApi(resolved.accessToken, {
+        refreshToken: resolved.refreshToken,
+        expiresAt: resolved.expiresAt,
+        clientId: clientId ?? undefined,
+        clientSecret: clientSecret ?? undefined,
+    });
+    linearApiCache = { instance, createdAt: now };
+    return instance;
+}
+// ── Comment wrapper that pre-registers comment ID for dedup ────────
+// When we create a comment, Linear fires Comment.create webhook back to us.
+// Register the comment ID immediately so the webhook handler skips it.
+// The `opts` parameter posts as a named OpenClaw agent identity (e.g.
+// createAsUser: "Mal" with avatar) — requires OAuth actor=app scope.
+async function createCommentWithDedup(linearApi, issueId, body, opts) {
+    const commentId = await linearApi.createComment(issueId, body, opts);
+    wasRecentlyProcessed(`comment:${commentId}`);
+    return commentId;
+}
+/**
+ * Post a comment as agent identity with prefix fallback.
+ * With gql() partial-success fix, the catch only fires for real failures.
+ */
+async function postAgentComment(api, linearApi, issueId, body, label, agentOpts) {
+    if (!agentOpts) {
+        await createCommentWithDedup(linearApi, issueId, `**[${label}]** ${body}`);
+        return;
+    }
+    try {
+        await createCommentWithDedup(linearApi, issueId, body, agentOpts);
+    }
+    catch (identityErr) {
+        api.logger.warn(`Agent identity comment failed: ${identityErr}`);
+        await createCommentWithDedup(linearApi, issueId, `**[${label}]** ${body}`);
+    }
+}
+function resolveAgentId(api) {
+    const fromConfig = api.pluginConfig?.defaultAgentId;
+    if (typeof fromConfig === "string" && fromConfig)
+        return fromConfig;
+    // Fall back to whatever is marked isDefault in agent profiles
+    const profiles = loadAgentProfiles();
+    const defaultAgent = Object.entries(profiles).find(([, p]) => p.isDefault);
+    if (!defaultAgent) {
+        throw new Error("No defaultAgentId in plugin config and no agent profile marked isDefault. Configure one in agent-profiles.json or set defaultAgentId in plugin config.");
+    }
+    return defaultAgent[0];
+}
+export async function handleLinearWebhook(api, req, res) {
+    if (req.method !== "POST") {
+        res.statusCode = 405;
+        res.end("Method Not Allowed");
+        return true;
+    }
+    const body = await readJsonBody(req, 1024 * 1024);
+    if (!body.ok) {
+        res.statusCode = 400;
+        res.end(body.error);
+        return true;
+    }
+    const payload = body.value;
+    // Structural validation — reject obviously invalid payloads early
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+        api.logger.warn("Linear webhook: invalid payload (not an object)");
+        res.statusCode = 400;
+        res.end("Invalid payload");
+        return true;
+    }
+    if (typeof payload.type !== "string") {
+        api.logger.warn(`Linear webhook: missing or non-string type field`);
+        res.statusCode = 400;
+        res.end("Missing type");
+        return true;
+    }
+    const pluginConfig = api.pluginConfig;
+    // Apply configurable dedup TTLs on each webhook (idempotent)
+    _configureDedupTtls(pluginConfig);
+    // Debug: log full payload structure for diagnosing webhook types
+    const payloadKeys = Object.keys(payload).join(", ");
+    api.logger.info(`Linear webhook received: type=${payload.type} action=${payload.action} keys=[${payloadKeys}]`);
+    emitDiagnostic(api, {
+        event: "webhook_received",
+        webhookType: payload.type,
+        webhookAction: payload.action,
+        identifier: payload.data?.identifier ?? payload.agentSession?.issue?.identifier,
+        issueId: payload.data?.id ?? payload.agentSession?.issue?.id,
+    });
+    // ── AppUserNotification — IGNORED ─────────────────────────────────
+    // AppUserNotification duplicates events already handled by the workspace
+    // webhook (Comment.create for mentions, Issue.update for assignments).
+    // Processing both causes double agent runs. Ack and discard.
+    if (payload.type === "AppUserNotification") {
+        api.logger.info(`AppUserNotification ignored (duplicate of workspace webhook): ${payload.notification?.type} appUserId=${payload.appUserId}`);
+        res.statusCode = 200;
+        res.end("ok");
+        return true;
+    }
+    // ── AgentSessionEvent.created — direct agent run ─────────────────
+    // User chatted with @ctclaw in Linear's agent session. Run the agent
+    // DIRECTLY with the user's message. The plan→implement→audit pipeline
+    // is only triggered from Issue.update delegation, not from chat.
+    if ((payload.type === "AgentSessionEvent" && payload.action === "created") ||
+        (payload.type === "AgentSession" && payload.action === "create")) {
+        // Respond within 5 seconds (Linear requirement)
+        res.statusCode = 200;
+        res.end("ok");
+        const session = payload.agentSession ?? payload.data;
+        const issue = session?.issue ?? payload.issue;
+        if (!session?.id || !issue?.id) {
+            api.logger.error("AgentSession.created missing session or issue data");
+            return true;
+        }
+        // Guard: check activeRuns FIRST (O(1), no side effects).
+        // This catches sessions created by our own handlers (Comment dispatch,
+        // Issue triage, handleDispatch) which all set activeRuns BEFORE calling
+        // createSessionOnIssue(). Checking this first prevents the race condition
+        // where the webhook arrives before wasRecentlyProcessed is registered.
+        if (activeRuns.has(issue.id)) {
+            api.logger.info(`Agent already running for ${issue?.identifier ?? issue?.id} — skipping session ${session.id}`);
+            return true;
+        }
+        // Secondary dedup: skip if we already handled this exact session ID
+        if (wasRecentlyProcessed(`session:${session.id}`)) {
+            api.logger.info(`AgentSession ${session.id} already handled — skipping`);
+            return true;
+        }
+        const linearApi = createLinearApi(api);
+        if (!linearApi) {
+            api.logger.error("No Linear access token configured");
+            return true;
+        }
+        // Validate agent profiles before doing any work
+        const profilesError = validateProfiles();
+        if (profilesError) {
+            api.logger.error("Agent profiles validation failed — posting setup error to Linear");
+            await linearApi.emitActivity(session.id, {
+                type: "error",
+                body: profilesError,
+            }).catch(() => { });
+            // Also try posting as a comment in case emitActivity doesn't render markdown
+            try {
+                await createCommentWithDedup(linearApi, issue.id, profilesError);
+            }
+            catch { }
+            return true;
+        }
+        const previousComments = payload.previousComments ?? [];
+        const guidanceCtx = extractGuidance(payload);
+        // Extract the user's latest message from previousComments (NOT from guidance)
+        const lastComment = previousComments.length > 0
+            ? previousComments[previousComments.length - 1]
+            : null;
+        const userMessage = lastComment?.body ?? "";
+        // Also extract the session prompt from promptContext — on initial session
+        // creation, previousComments is empty but the user's message lives here.
+        const promptContext = typeof payload.promptContext === "string" ? payload.promptContext : "";
+        // Route to the mentioned agent if the user's message contains an @mention.
+        // AgentSessionEvent doesn't carry mention routing — we must check manually.
+        // Check the last comment body, promptContext, AND agentSession prompt for @mentions.
+        const profiles = loadAgentProfiles();
+        const mentionPattern = buildMentionPattern(profiles);
+        let agentId = resolveAgentId(api);
+        let mentionOverride = false;
+        const sessionPrompt = typeof payload.agentSession?.prompt === "string"
+            ? payload.agentSession.prompt : "";
+        const textsToScan = [userMessage, sessionPrompt, promptContext].filter(Boolean);
+        for (const text of textsToScan) {
+            if (mentionOverride)
+                break;
+            if (mentionPattern) {
+                mentionPattern.lastIndex = 0;
+                const mentionMatch = text.match(mentionPattern);
+                if (mentionMatch) {
+                    const alias = mentionMatch[1];
+                    const resolved = resolveAgentFromAlias(alias, profiles);
+                    if (resolved) {
+                        api.logger.info(`AgentSession routed to ${resolved.agentId} via @${alias} mention in ${text === userMessage ? "comment" : text === sessionPrompt ? "session prompt" : "promptContext"}`);
+                        agentId = resolved.agentId;
+                        mentionOverride = true;
+                    }
+                }
+            }
+        }
+        // Also try bare-name matching (e.g. "hey mal" without @) in the user's text
+        if (!mentionOverride) {
+            for (const text of textsToScan) {
+                if (mentionOverride)
+                    break;
+                const lowerText = text.toLowerCase();
+                for (const [id, profile] of Object.entries(profiles)) {
+                    const allNames = [...profile.mentionAliases, ...(profile.appAliases ?? [])];
+                    for (const name of allNames) {
+                        // Match bare name at word boundary (e.g. "hey mal" but not "malware")
+                        const nameRe = new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i");
+                        if (nameRe.test(lowerText)) {
+                            api.logger.info(`AgentSession routed to ${id} via bare name "${name}" in ${text === userMessage ? "comment" : text === sessionPrompt ? "session prompt" : "promptContext"}`);
+                            agentId = id;
+                            mentionOverride = true;
+                            break;
+                        }
+                    }
+                    if (mentionOverride)
+                        break;
+                }
+            }
+        }
+        // Session affinity: if no @mention override, prefer the agent that last handled this issue
+        if (!mentionOverride && issue?.id) {
+            const affinityAgent = getIssueAffinity(issue.id);
+            if (affinityAgent) {
+                api.logger.info(`AgentSession routed to ${affinityAgent} via session affinity for ${issue.identifier ?? issue.id}`);
+                agentId = affinityAgent;
+            }
+        }
+        // Fetch full issue details (needed for team routing + description)
+        let enrichedIssue = issue;
+        try {
+            enrichedIssue = await linearApi.getIssueDetails(issue.id);
+        }
+        catch (err) {
+            api.logger.warn(`Could not fetch issue details: ${err}`);
+        }
+        // Team-based agent routing: if no mention or affinity override, try team mapping
+        const teamKey = enrichedIssue?.team?.key;
+        if (!mentionOverride && agentId === resolveAgentId(api) && teamKey) {
+            const teamMappings = pluginConfig?.teamMappings;
+            const teamDefault = teamMappings?.[teamKey]?.defaultAgent;
+            if (typeof teamDefault === "string") {
+                api.logger.info(`AgentSession routed to ${teamDefault} via team mapping (${teamKey})`);
+                agentId = teamDefault;
+            }
+        }
+        api.logger.info(`AgentSession created: ${session.id} for issue ${issue?.identifier ?? issue?.id} agent=${agentId} team=${teamKey ?? "?"} (comments: ${previousComments.length}, guidance: ${guidanceCtx.guidance ? "yes" : "no"})`);
+        const description = enrichedIssue?.description ?? issue?.description ?? "(no description)";
+        // Cache guidance for this team (enables Comment webhook paths)
+        const teamId = enrichedIssue?.team?.id;
+        if (guidanceCtx.guidance && teamId)
+            cacheGuidanceForTeam(teamId, guidanceCtx.guidance);
+        const guidanceAppendix = isGuidanceEnabled(pluginConfig, teamId)
+            ? formatGuidanceAppendix(guidanceCtx.guidance)
+            : "";
+        // Build conversation context from previous comments
+        const commentContext = previousComments
+            .slice(-5)
+            .map((c) => `**${c.user?.name ?? c.actorName ?? "User"}**: ${(c.body ?? "").slice(0, 300)}`)
+            .join("\n\n");
+        const issueRef = enrichedIssue?.identifier ?? issue.identifier ?? issue.id;
+        const stateType = enrichedIssue?.state?.type ?? "";
+        const isTriaged = stateType === "started" || stateType === "completed" || stateType === "canceled";
+        const cliTool = resolveToolName(loadCodingConfig(), agentId);
+        const toolAccessLines = isTriaged
+            ? [
+                `**Tool access:**`,
+                `- \`linear_issues\` tool: Full access. Use action="read" with issueId="${issueRef}" to get details, action="create" to create issues (with parentIssueId to create sub-issues for granular work breakdown), action="update" with status/priority/labels/estimate to modify issues, action="comment" to post comments, action="list_states" to see available workflow states.`,
+                `- \`${cliTool}\`: Dispatch coding work to a worker. Workers return text — they cannot access linear_issues.`,
+                `- \`spawn_agent\`/\`ask_agent\`: Delegate to other crew agents.`,
+                `- Standard tools: exec, read, edit, write, web_search, etc.`,
+                ``,
+                `**Sub-issue guidance:** When a task is too large or has multiple distinct parts, break it into sub-issues using action="create" with parentIssueId="${issueRef}". Each sub-issue should be an atomic, independently testable unit of work with its own acceptance criteria. This enables parallel dispatch and clearer progress tracking.`,
+            ]
+            : [
+                `**Tool access:**`,
+                `- \`linear_issues\` tool: READ ONLY. Use action="read" with issueId="${issueRef}" to get details, action="list_states"/"list_labels" for metadata. Do NOT use action="update", action="create", or action="comment".`,
+                `- \`${cliTool}\`: **Planning mode only.** Workers may explore code and write plan files (PLAN.md, design docs). Workers MUST NOT create, modify, or delete source code, run deployments, or make system changes. Use for codebase exploration and planning only.`,
+                `- \`spawn_agent\`/\`ask_agent\`: Delegate to other crew agents.`,
+                `- Standard tools: exec, read, edit, write, web_search, etc.`,
+            ];
+        const roleLines = isTriaged
+            ? [`**Your role:** Orchestrator with full Linear access. You can update issue fields, change status, and dispatch work via \`${cliTool}\`. Do NOT post comments yourself — the handler posts your text output.`]
+            : [`**Your role:** You are the dispatcher. For any coding or implementation work, use \`${cliTool}\` to dispatch it. Workers return text output. You summarize results. You do NOT update issue status or post comments via linear_issues — the audit system handles lifecycle transitions.`];
+        if (guidanceAppendix) {
+            api.logger.info(`Guidance injected (${guidanceCtx.source}): ${guidanceCtx.guidance?.slice(0, 120)}...`);
+        }
+        // ── Intent gate: classify user request and block work requests on untriaged issues ──
+        const classifyText = userMessage || promptContext || enrichedIssue?.title || "";
+        const projectId = enrichedIssue?.project?.id;
+        let isPlanning = false;
+        if (projectId) {
+            try {
+                const planState = await readPlanningState(pluginConfig?.planningStatePath);
+                isPlanning = isInPlanningMode(planState, projectId);
+            }
+            catch { /* proceed without planning context */ }
+        }
+        const intentResult = await classifyIntent(api, {
+            commentBody: classifyText,
+            issueTitle: enrichedIssue?.title ?? "(untitled)",
+            issueStatus: enrichedIssue?.state?.name,
+            isPlanning,
+            agentNames: Object.keys(profiles),
+            hasProject: !!projectId,
+        }, pluginConfig);
+        api.logger.info(`AgentSession.created intent: ${intentResult.intent}${intentResult.agentId ? ` (agent: ${intentResult.agentId})` : ""} — ${intentResult.reasoning}`);
+        const blockMsg = shouldBlockWorkRequest(intentResult.intent, stateType, enrichedIssue?.state?.name ?? "Unknown", issueRef);
+        if (blockMsg) {
+            api.logger.info(`AgentSession.created: blocking work request on untriaged issue ${issueRef}`);
+            await linearApi.emitActivity(session.id, { type: "response", body: blockMsg }).catch(() => { });
+            return true;
+        }
+        const message = [
+            `You are an orchestrator responding in a Linear issue session. Your text output will be posted as activities visible to the user.`,
+            ``,
+            ...toolAccessLines,
+            ``,
+            ...roleLines,
+            guidanceAppendix ? `\n${guidanceAppendix}` : "",
+            ``,
+            `## Issue: ${issueRef} — ${enrichedIssue?.title ?? issue.title ?? "(untitled)"}`,
+            `**Status:** ${enrichedIssue?.state?.name ?? "Unknown"} | **Assignee:** ${enrichedIssue?.assignee?.name ?? "Unassigned"}`,
+            ``,
+            `**Description:**`,
+            description,
+            commentContext ? `\n**Conversation:**\n${commentContext}` : "",
+            userMessage ? `\n**Latest message:**\n> ${userMessage}` : "",
+            ``,
+            `## Scope Rules`,
+            `1. **Read the issue first.** The issue title + description define your scope. Everything you do must serve the issue as written.`,
+            `2. **\`${cliTool}\` is ONLY for issue-body work.** Only dispatch \`${cliTool}\` when the issue description contains implementation requirements. A greeting, question, or conversational issue gets a conversational response — NOT ${cliTool}.`,
+            `3. **Comments explore, issue body builds.** User comments may explore scope or ask questions but NEVER trigger \`${cliTool}\` alone. If a comment requests new implementation, update the issue description first, then build from the issue text.`,
+            `4. **Plan before building.** For non-trivial work, respond with a plan first. Only dispatch \`${cliTool}\` after the plan is clear and grounded in the issue body.`,
+            `5. **Match response to request.** Greeting → greet. Question → answer. No implementation requirements → no ${cliTool}.`,
+            ``,
+            `Respond within the scope defined above. Be concise and action-oriented.`,
+        ].filter(Boolean).join("\n");
+        // Run agent directly (non-blocking)
+        activeRuns.add(issue.id);
+        void (async () => {
+            const profiles = loadAgentProfiles();
+            const label = profiles[agentId]?.label ?? agentId;
+            // Register active session for tool resolution (cli_codex, etc.)
+            // Also eagerly records affinity so follow-ups route to the same agent.
+            setActiveSession({
+                agentSessionId: session.id,
+                issueIdentifier: enrichedIssue?.identifier ?? issue.identifier ?? issue.id,
+                issueId: issue.id,
+                agentId,
+                startedAt: Date.now(),
+            });
+            try {
+                // Emit initial thought
+                await linearApi.emitActivity(session.id, {
+                    type: "thought",
+                    body: `${label} is processing request for ${enrichedIssue?.identifier ?? issue.id}...`,
+                }).catch(() => { });
+                // Run agent with streaming to Linear
+                const sessionId = `linear-session-${session.id}`;
+                const { runAgent } = await import("../agent/agent.js");
+                const result = await runAgent({
+                    api,
+                    agentId,
+                    sessionId,
+                    message,
+                    timeoutMs: 5 * 60_000,
+                    streaming: {
+                        linearApi,
+                        agentSessionId: session.id,
+                    },
+                });
+                const responseBody = result.success
+                    ? result.output
+                    : `Something went wrong while processing this. The system will retry automatically if possible. If this keeps happening, run \`openclaw openclaw-linear doctor\` to check for issues.`;
+                // Emit response via session (preferred — avoids duplicate comment).
+                // Fall back to a regular comment only if emitActivity fails.
+                const labeledResponse = `**[${label}]** ${responseBody}`;
+                const emitted = await linearApi.emitActivity(session.id, {
+                    type: "response",
+                    body: labeledResponse,
+                }).then(() => true).catch(() => false);
+                if (!emitted) {
+                    const avatarUrl = profiles[agentId]?.avatarUrl;
+                    const agentOpts = avatarUrl
+                        ? { createAsUser: label, displayIconUrl: avatarUrl }
+                        : undefined;
+                    await postAgentComment(api, linearApi, issue.id, responseBody, label, agentOpts);
+                }
+                api.logger.info(`Posted agent response to ${enrichedIssue?.identifier ?? issue.id} (session ${session.id})`);
+            }
+            catch (err) {
+                api.logger.error(`AgentSession handler error: ${err}`);
+                await linearApi.emitActivity(session.id, {
+                    type: "error",
+                    body: `Failed: ${String(err).slice(0, 500)}`,
+                }).catch(() => { });
+            }
+            finally {
+                clearActiveSession(issue.id);
+                activeRuns.delete(issue.id);
+            }
+        })();
+        return true;
+    }
+    // ── AgentSession.prompted — follow-up user messages in existing sessions
+    // Also fires when we emit activities (feedback loop). Use activeRuns guard
+    // and webhookId dedup to distinguish user follow-ups from our own emissions.
+    if ((payload.type === "AgentSessionEvent" && payload.action === "prompted") ||
+        (payload.type === "AgentSession" && payload.action === "prompted")) {
+        res.statusCode = 200;
+        res.end("ok");
+        const session = payload.agentSession ?? payload.data;
+        const issue = session?.issue ?? payload.issue;
+        const activity = payload.agentActivity;
+        if (!session?.id || !issue?.id) {
+            api.logger.info(`AgentSession prompted: missing session or issue — ignoring`);
+            return true;
+        }
+        // ── Steering gate: three-way routing during active runs ──
+        // 1. Filter our own emitted activities (feedback loop prevention)
+        const activityType = activity?.content?.type;
+        const activityBody = activity?.content?.body ?? activity?.body ?? "";
+        const isOurFeedback = activityType === "thought" ||
+            activityType === "action" ||
+            activityType === "response" ||
+            activityType === "error" ||
+            activityType === "elicitation" ||
+            (typeof activityBody === "string" && wasRecentlyEmitted(activityBody));
+        if (isOurFeedback) {
+            api.logger.info(`AgentSession prompted: ${session.id} — feedback from own activity (${activityType ?? "hash-match"}), ignoring`);
+            return true;
+        }
+        // 2. If active dispatch with tmux session → route to steering orchestrator
+        const tmuxSession = getActiveTmuxSession(issue.id);
+        if (tmuxSession) {
+            const userText = activityBody;
+            if (!userText || typeof userText !== "string" || !userText.trim()) {
+                api.logger.info(`AgentSession prompted: ${session.id} — tmux active but empty user message, ignoring`);
+                return true;
+            }
+            api.logger.info(`AgentSession prompted: ${session.id} issue=${issue?.identifier ?? issue?.id} — routing to steering orchestrator (${tmuxSession.backend})`);
+            void handleSteeringInput(api, {
+                session,
+                issue,
+                userMessage: userText,
+                tmuxSession,
+                pluginConfig: pluginConfig,
+            });
+            return true;
+        }
+        // 3. No tmux session but active run → existing behavior (ignore feedback)
+        if (activeRuns.has(issue.id)) {
+            api.logger.info(`AgentSession prompted: ${session.id} issue=${issue?.identifier ?? issue?.id} — agent active, no tmux, ignoring (feedback)`);
+            return true;
+        }
+        // Dedup by webhookId
+        const webhookId = payload.webhookId;
+        if (webhookId && wasRecentlyProcessed(`webhook:${webhookId}`)) {
+            api.logger.info(`AgentSession prompted: webhook ${webhookId} already processed — skipping`);
+            return true;
+        }
+        // Extract user message from the activity (not from promptContext which contains issue data + guidance)
+        const guidanceCtxPrompted = extractGuidance(payload);
+        const userMessage = activity?.content?.body ??
+            activity?.body ??
+            "";
+        if (!userMessage || typeof userMessage !== "string" || userMessage.trim().length === 0) {
+            api.logger.info(`AgentSession prompted: ${session.id} — no user message found, ignoring`);
+            return true;
+        }
+        const linearApi = createLinearApi(api);
+        if (!linearApi) {
+            api.logger.error("No Linear access token configured");
+            return true;
+        }
+        // Validate agent profiles before doing any work
+        const profilesError = validateProfiles();
+        if (profilesError) {
+            api.logger.error("Agent profiles validation failed — posting setup error to Linear");
+            await linearApi.emitActivity(session.id, {
+                type: "error",
+                body: profilesError,
+            }).catch(() => { });
+            return true;
+        }
+        // Route to mentioned agent if user's message contains an @mention (one-time detour)
+        const promptedProfiles = loadAgentProfiles();
+        const promptedMentionPattern = buildMentionPattern(promptedProfiles);
+        let agentId = resolveAgentId(api);
+        let mentionOverride = false;
+        if (promptedMentionPattern && userMessage) {
+            const mentionMatch = userMessage.match(promptedMentionPattern);
+            if (mentionMatch) {
+                const alias = mentionMatch[1];
+                const resolved = resolveAgentFromAlias(alias, promptedProfiles);
+                if (resolved) {
+                    api.logger.info(`AgentSession prompted: routed to ${resolved.agentId} via @${alias} mention`);
+                    agentId = resolved.agentId;
+                    mentionOverride = true;
+                }
+            }
+        }
+        // Session affinity: if no @mention override, prefer the agent that last handled this issue
+        if (!mentionOverride && issue?.id) {
+            const affinityAgent = getIssueAffinity(issue.id);
+            if (affinityAgent) {
+                api.logger.info(`AgentSession prompted: routed to ${affinityAgent} via session affinity for ${issue.identifier ?? issue.id}`);
+                agentId = affinityAgent;
+            }
+        }
+        api.logger.info(`AgentSession prompted (follow-up): ${session.id} issue=${issue?.identifier ?? issue?.id} agent=${agentId} message="${userMessage.slice(0, 80)}..."`);
+        // Run agent for follow-up (non-blocking)
+        activeRuns.add(issue.id);
+        void (async () => {
+            const profiles = loadAgentProfiles();
+            const label = profiles[agentId]?.label ?? agentId;
+            // Fetch full issue details for context
+            let enrichedIssue = issue;
+            try {
+                enrichedIssue = await linearApi.getIssueDetails(issue.id);
+            }
+            catch (err) {
+                api.logger.warn(`Could not fetch issue details: ${err}`);
+            }
+            const description = enrichedIssue?.description ?? issue?.description ?? "(no description)";
+            // Resolve guidance for follow-up
+            const followUpTeamId = enrichedIssue?.team?.id;
+            if (guidanceCtxPrompted.guidance && followUpTeamId)
+                cacheGuidanceForTeam(followUpTeamId, guidanceCtxPrompted.guidance);
+            const followUpGuidanceAppendix = isGuidanceEnabled(pluginConfig, followUpTeamId)
+                ? formatGuidanceAppendix(guidanceCtxPrompted.guidance ?? (followUpTeamId ? getCachedGuidanceForTeam(followUpTeamId) : null))
+                : "";
+            // Build context from recent comments
+            const recentComments = enrichedIssue?.comments?.nodes ?? [];
+            const commentContext = recentComments
+                .slice(-5)
+                .map((c) => `**${c.user?.name ?? "User"}**: ${(c.body ?? "").slice(0, 300)}`)
+                .join("\n\n");
+            const followUpIssueRef = enrichedIssue?.identifier ?? issue.identifier ?? issue.id;
+            const followUpStateType = enrichedIssue?.state?.type ?? "";
+            const followUpIsTriaged = followUpStateType === "started" || followUpStateType === "completed" || followUpStateType === "canceled";
+            const followUpCliTool = resolveToolName(loadCodingConfig(), agentId);
+            const followUpToolAccessLines = followUpIsTriaged
+                ? [
+                    `**Tool access:**`,
+                    `- \`linear_issues\` tool: Full access. Use action="read" with issueId="${followUpIssueRef}" to get details, action="create" to create issues (with parentIssueId to create sub-issues for granular work breakdown), action="update" with status/priority/labels/estimate to modify issues, action="comment" to post comments, action="list_states" to see available workflow states.`,
+                    `- \`${followUpCliTool}\`: Dispatch coding work to a worker. Workers return text — they cannot access linear_issues.`,
+                    `- \`spawn_agent\`/\`ask_agent\`: Delegate to other crew agents.`,
+                    `- Standard tools: exec, read, edit, write, web_search, etc.`,
+                    ``,
+                    `**Sub-issue guidance:** When a task is too large or has multiple distinct parts, break it into sub-issues using action="create" with parentIssueId="${followUpIssueRef}". Each sub-issue should be an atomic, independently testable unit of work with its own acceptance criteria. This enables parallel dispatch and clearer progress tracking.`,
+                ]
+                : [
+                    `**Tool access:**`,
+                    `- \`linear_issues\` tool: READ ONLY. Use action="read" with issueId="${followUpIssueRef}" to get details, action="list_states"/"list_labels" for metadata. Do NOT use action="update", action="create", or action="comment".`,
+                    `- \`${followUpCliTool}\`: **Planning mode only.** Workers may explore code and write plan files (PLAN.md, design docs). Workers MUST NOT create, modify, or delete source code, run deployments, or make system changes. Use for codebase exploration and planning only.`,
+                    `- \`spawn_agent\`/\`ask_agent\`: Delegate to other crew agents.`,
+                    `- Standard tools: exec, read, edit, write, web_search, etc.`,
+                ];
+            const followUpRoleLines = followUpIsTriaged
+                ? [`**Your role:** Orchestrator with full Linear access. You can update issue fields, change status, and dispatch work via \`${followUpCliTool}\`. Do NOT post comments yourself — the handler posts your text output.`]
+                : [`**Your role:** Dispatcher. For work requests, use \`${followUpCliTool}\`. You do NOT update issue status — the audit system handles lifecycle.`];
+            if (followUpGuidanceAppendix) {
+                api.logger.info(`Follow-up guidance injected: ${(guidanceCtxPrompted.guidance ?? "cached").slice(0, 120)}...`);
+            }
+            // ── Intent gate: classify follow-up and block work requests on untriaged issues ──
+            const followUpProjectId = enrichedIssue?.project?.id;
+            let followUpIsPlanning = false;
+            if (followUpProjectId) {
+                try {
+                    const planState = await readPlanningState(pluginConfig?.planningStatePath);
+                    followUpIsPlanning = isInPlanningMode(planState, followUpProjectId);
+                }
+                catch { /* proceed without planning context */ }
+            }
+            const followUpIntentResult = await classifyIntent(api, {
+                commentBody: userMessage,
+                issueTitle: enrichedIssue?.title ?? "(untitled)",
+                issueStatus: enrichedIssue?.state?.name,
+                isPlanning: followUpIsPlanning,
+                agentNames: Object.keys(profiles),
+                hasProject: !!followUpProjectId,
+            }, pluginConfig);
+            api.logger.info(`AgentSession.prompted intent: ${followUpIntentResult.intent}${followUpIntentResult.agentId ? ` (agent: ${followUpIntentResult.agentId})` : ""} — ${followUpIntentResult.reasoning}`);
+            const followUpBlockMsg = shouldBlockWorkRequest(followUpIntentResult.intent, followUpStateType, enrichedIssue?.state?.name ?? "Unknown", followUpIssueRef);
+            if (followUpBlockMsg) {
+                api.logger.info(`AgentSession.prompted: blocking work request on untriaged issue ${followUpIssueRef}`);
+                await linearApi.emitActivity(session.id, { type: "response", body: followUpBlockMsg }).catch(() => { });
+                activeRuns.delete(issue.id);
+                return;
+            }
+            const message = [
+                `You are an orchestrator responding in a Linear issue session. Your text output will be posted as activities visible to the user.`,
+                ``,
+                ...followUpToolAccessLines,
+                ``,
+                ...followUpRoleLines,
+                followUpGuidanceAppendix ? `\n${followUpGuidanceAppendix}` : "",
+                ``,
+                `## Issue: ${followUpIssueRef} — ${enrichedIssue?.title ?? issue.title ?? "(untitled)"}`,
+                `**Status:** ${enrichedIssue?.state?.name ?? "Unknown"} | **Assignee:** ${enrichedIssue?.assignee?.name ?? "Unassigned"}`,
+                ``,
+                `**Description:**`,
+                description,
+                commentContext ? `\n**Recent conversation:**\n${commentContext}` : "",
+                `\n**User's follow-up message:**\n> ${userMessage}`,
+                ``,
+                `## Scope Rules`,
+                `1. **The issue body is your scope.** Re-read the description above before acting.`,
+                `2. **Comments explore, issue body builds.** The follow-up may refine understanding or ask questions — NEVER dispatch \`${followUpCliTool}\` from a comment alone. If the user requests implementation, suggest updating the issue description first.`,
+                `3. **Match response to request.** Answer questions with answers. Do NOT escalate conversational messages into builds.`,
+                ``,
+                `Respond to the follow-up within the scope defined above. Be concise and action-oriented.`,
+            ].filter(Boolean).join("\n");
+            setActiveSession({
+                agentSessionId: session.id,
+                issueIdentifier: enrichedIssue?.identifier ?? issue.identifier ?? issue.id,
+                issueId: issue.id,
+                agentId,
+                startedAt: Date.now(),
+            });
+            try {
+                await linearApi.emitActivity(session.id, {
+                    type: "thought",
+                    body: `${label} is processing follow-up for ${enrichedIssue?.identifier ?? issue.id}...`,
+                }).catch(() => { });
+                const sessionId = `linear-session-${session.id}`;
+                const { runAgent } = await import("../agent/agent.js");
+                const result = await runAgent({
+                    api,
+                    agentId,
+                    sessionId,
+                    message,
+                    timeoutMs: 5 * 60_000,
+                    streaming: {
+                        linearApi,
+                        agentSessionId: session.id,
+                    },
+                });
+                const responseBody = result.success
+                    ? result.output
+                    : `Something went wrong while processing this. The system will retry automatically if possible. If this keeps happening, run \`openclaw openclaw-linear doctor\` to check for issues.`;
+                // Emit response via session (preferred). Fall back to comment if it fails.
+                const labeledResponse = `**[${label}]** ${responseBody}`;
+                const emitted = await linearApi.emitActivity(session.id, {
+                    type: "response",
+                    body: labeledResponse,
+                }).then(() => true).catch(() => false);
+                if (!emitted) {
+                    const avatarUrl = profiles[agentId]?.avatarUrl;
+                    const agentOpts = avatarUrl
+                        ? { createAsUser: label, displayIconUrl: avatarUrl }
+                        : undefined;
+                    await postAgentComment(api, linearApi, issue.id, responseBody, label, agentOpts);
+                }
+                api.logger.info(`Posted follow-up response to ${enrichedIssue?.identifier ?? issue.id} (session ${session.id})`);
+            }
+            catch (err) {
+                api.logger.error(`AgentSession prompted handler error: ${err}`);
+                await linearApi.emitActivity(session.id, {
+                    type: "error",
+                    body: `Failed: ${String(err).slice(0, 500)}`,
+                }).catch(() => { });
+            }
+            finally {
+                clearActiveSession(issue.id);
+                activeRuns.delete(issue.id);
+            }
+        })();
+        return true;
+    }
+    // ── Comment.create — intent-based routing ────────────────────────
+    if (payload.type === "Comment" && payload.action === "create") {
+        res.statusCode = 200;
+        res.end("ok");
+        const comment = payload.data;
+        const commentBody = comment?.body ?? "";
+        const commentor = comment?.user?.name ?? "Unknown";
+        const issue = comment?.issue ?? payload.issue;
+        if (!issue?.id) {
+            api.logger.error("Comment webhook: missing issue data");
+            return true;
+        }
+        // Dedup on comment ID
+        if (comment?.id && wasRecentlyProcessed(`comment:${comment.id}`)) {
+            api.logger.info(`Comment ${comment.id} already processed — skipping`);
+            return true;
+        }
+        const linearApi = createLinearApi(api);
+        if (!linearApi) {
+            api.logger.error("No Linear access token — cannot process comment");
+            return true;
+        }
+        // Skip bot's own comments
+        try {
+            const viewerId = await linearApi.getViewerId();
+            if (viewerId && comment?.user?.id === viewerId) {
+                api.logger.info(`Comment webhook: skipping our own comment on ${issue.identifier ?? issue.id}`);
+                return true;
+            }
+        }
+        catch { /* proceed if viewerId check fails */ }
+        // Early guard: skip if an agent run is already active for this issue.
+        // Avoids wasted LLM intent classification (~2-5s) when result would
+        // be discarded anyway by activeRuns check in dispatchCommentToAgent().
+        if (activeRuns.has(issue.id)) {
+            api.logger.info(`Comment on ${issue.identifier ?? issue.id}: active run — skipping`);
+            return true;
+        }
+        // Validate agent profiles before doing any work
+        const profilesError = validateProfiles();
+        if (profilesError) {
+            api.logger.error("Agent profiles validation failed — posting setup error to Linear");
+            try {
+                await createCommentWithDedup(linearApi, issue.id, profilesError);
+            }
+            catch { }
+            return true;
+        }
+        // Load agent profiles
+        const profiles = loadAgentProfiles();
+        const agentNames = Object.keys(profiles);
+        // ── @mention fast path — with intent gate ────────────────────
+        const mentionPattern = buildMentionPattern(profiles);
+        const mentionMatches = mentionPattern ? commentBody.match(mentionPattern) : null;
+        if (mentionMatches && mentionMatches.length > 0) {
+            const alias = mentionMatches[0].replace("@", "");
+            const resolved = resolveAgentFromAlias(alias, profiles);
+            if (resolved) {
+                api.logger.info(`Comment @mention fast path: @${resolved.agentId} on ${issue.identifier ?? issue.id}`);
+                // Classify intent even on @mention path to gate work requests
+                let enrichedForGate = issue;
+                try {
+                    enrichedForGate = await linearApi.getIssueDetails(issue.id);
+                }
+                catch { }
+                const mentionStateType = enrichedForGate?.state?.type ?? "";
+                const mentionProjectId = enrichedForGate?.project?.id;
+                let mentionIsPlanning = false;
+                if (mentionProjectId) {
+                    try {
+                        const planState = await readPlanningState(pluginConfig?.planningStatePath);
+                        mentionIsPlanning = isInPlanningMode(planState, mentionProjectId);
+                    }
+                    catch { }
+                }
+                const mentionIntentResult = await classifyIntent(api, {
+                    commentBody,
+                    issueTitle: enrichedForGate?.title ?? "(untitled)",
+                    issueStatus: enrichedForGate?.state?.name,
+                    isPlanning: mentionIsPlanning,
+                    agentNames,
+                    hasProject: !!mentionProjectId,
+                }, pluginConfig);
+                api.logger.info(`Comment @mention intent: ${mentionIntentResult.intent} — ${mentionIntentResult.reasoning}`);
+                const mentionBlockMsg = shouldBlockWorkRequest(mentionIntentResult.intent, mentionStateType, enrichedForGate?.state?.name ?? "Unknown", enrichedForGate?.identifier ?? issue.identifier ?? issue.id);
+                if (mentionBlockMsg) {
+                    api.logger.info(`Comment @mention: blocking work request on untriaged issue ${enrichedForGate?.identifier ?? issue.identifier ?? issue.id}`);
+                    try {
+                        await createCommentWithDedup(linearApi, issue.id, mentionBlockMsg);
+                    }
+                    catch { }
+                    return true;
+                }
+                void dispatchCommentToAgent(api, linearApi, profiles, resolved.agentId, issue, comment, commentBody, commentor, pluginConfig)
+                    .catch((err) => api.logger.error(`Comment dispatch error: ${err}`));
+                return true;
+            }
+        }
+        // ── Intent classification ─────────────────────────────────────
+        // Fetch issue details for context
+        let enrichedIssue = issue;
+        try {
+            enrichedIssue = await linearApi.getIssueDetails(issue.id);
+        }
+        catch (err) {
+            api.logger.warn(`Could not fetch issue details: ${err}`);
+        }
+        const projectId = enrichedIssue?.project?.id;
+        const planStatePath = pluginConfig?.planningStatePath;
+        // Determine planning state
+        let isPlanning = false;
+        let planSession = null;
+        if (projectId) {
+            try {
+                const planState = await readPlanningState(planStatePath);
+                isPlanning = isInPlanningMode(planState, projectId);
+                if (isPlanning) {
+                    planSession = getPlanningSession(planState, projectId);
+                }
+            }
+            catch { /* proceed without planning context */ }
+        }
+        const intentResult = await classifyIntent(api, {
+            commentBody,
+            issueTitle: enrichedIssue?.title ?? "(untitled)",
+            issueStatus: enrichedIssue?.state?.name,
+            isPlanning,
+            agentNames,
+            hasProject: !!projectId,
+        }, pluginConfig);
+        api.logger.info(`Comment intent: ${intentResult.intent}${intentResult.agentId ? ` (agent: ${intentResult.agentId})` : ""} — ${intentResult.reasoning} (fallback: ${intentResult.fromFallback})`);
+        // ── Gate work requests on untriaged issues ────────────────────
+        const commentStateType = enrichedIssue?.state?.type ?? "";
+        const commentBlockMsg = shouldBlockWorkRequest(intentResult.intent, commentStateType, enrichedIssue?.state?.name ?? "Unknown", enrichedIssue?.identifier ?? issue.identifier ?? issue.id);
+        if (commentBlockMsg) {
+            api.logger.info(`Comment: blocking work request on untriaged issue ${enrichedIssue?.identifier ?? issue.identifier ?? issue.id}`);
+            try {
+                await createCommentWithDedup(linearApi, issue.id, commentBlockMsg);
+            }
+            catch { }
+            return true;
+        }
+        // ── Route by intent ────────────────────────────────────────────
+        switch (intentResult.intent) {
+            case "plan_start": {
+                if (!projectId) {
+                    api.logger.info("Comment intent plan_start but no project — ignoring");
+                    break;
+                }
+                if (isPlanning) {
+                    api.logger.info("Comment intent plan_start but already planning — treating as plan_continue");
+                    // Fall through to plan_continue
+                    if (planSession) {
+                        void handlePlannerTurn({ api, linearApi, pluginConfig }, planSession, { issueId: issue.id, commentBody, commentorName: commentor }).catch((err) => api.logger.error(`Planner turn error: ${err}`));
+                    }
+                    break;
+                }
+                api.logger.info(`Planning: initiation requested on ${issue.identifier ?? issue.id}`);
+                void initiatePlanningSession({ api, linearApi, pluginConfig }, projectId, { id: issue.id, identifier: enrichedIssue.identifier, title: enrichedIssue.title, team: enrichedIssue.team }).catch((err) => api.logger.error(`Planning initiation error: ${err}`));
+                break;
+            }
+            case "plan_finalize": {
+                if (!isPlanning || !planSession) {
+                    api.logger.info("Comment intent plan_finalize but not in planning mode — ignoring");
+                    break;
+                }
+                if (planSession.status === "plan_review") {
+                    // Already passed audit + cross-model review — approve directly
+                    api.logger.info(`Planning: approving plan for ${planSession.projectName} (from plan_review)`);
+                    void (async () => {
+                        try {
+                            await endPlanningSession(planSession.projectId, "approved", planStatePath);
+                            await createCommentWithDedup(linearApi, planSession.rootIssueId, `## Plan Approved\n\nPlan for **${planSession.projectName}** has been approved. Dispatching to workers.`);
+                            // Trigger DAG dispatch
+                            const notify = createNotifierFromConfig(pluginConfig, api.runtime, api);
+                            const hookCtx = {
+                                api, linearApi, notify, pluginConfig,
+                                configPath: pluginConfig?.dispatchStatePath,
+                            };
+                            await startProjectDispatch(hookCtx, planSession.projectId);
+                        }
+                        catch (err) {
+                            api.logger.error(`Plan approval error: ${err}`);
+                        }
+                    })();
+                }
+                else {
+                    // Still interviewing — run audit (which transitions to plan_review)
+                    void runPlanAudit({ api, linearApi, pluginConfig }, planSession).catch((err) => api.logger.error(`Plan audit error: ${err}`));
+                }
+                break;
+            }
+            case "plan_abandon": {
+                if (!isPlanning || !planSession) {
+                    api.logger.info("Comment intent plan_abandon but not in planning mode — ignoring");
+                    break;
+                }
+                void (async () => {
+                    try {
+                        await endPlanningSession(planSession.projectId, "abandoned", planStatePath);
+                        await createCommentWithDedup(linearApi, planSession.rootIssueId, `Planning mode ended for **${planSession.projectName}**. Session abandoned.`);
+                        api.logger.info(`Planning: session abandoned for ${planSession.projectName}`);
+                    }
+                    catch (err) {
+                        api.logger.error(`Plan abandon error: ${err}`);
+                    }
+                })();
+                break;
+            }
+            case "plan_continue": {
+                if (!isPlanning || !planSession) {
+                    // Not in planning mode — treat as general
+                    const planContinueAgent = getIssueAffinity(issue.id) ?? resolveAgentId(api);
+                    api.logger.info(`Comment intent plan_continue but not in planning mode — dispatching to ${planContinueAgent}`);
+                    void dispatchCommentToAgent(api, linearApi, profiles, planContinueAgent, issue, comment, commentBody, commentor, pluginConfig)
+                        .catch((err) => api.logger.error(`Comment dispatch error: ${err}`));
+                    break;
+                }
+                void handlePlannerTurn({ api, linearApi, pluginConfig }, planSession, { issueId: issue.id, commentBody, commentorName: commentor }).catch((err) => api.logger.error(`Planner turn error: ${err}`));
+                break;
+            }
+            case "ask_agent": {
+                const targetAgent = intentResult.agentId ?? resolveAgentId(api);
+                api.logger.info(`Comment intent ask_agent: routing to ${targetAgent}`);
+                void dispatchCommentToAgent(api, linearApi, profiles, targetAgent, issue, comment, commentBody, commentor, pluginConfig)
+                    .catch((err) => api.logger.error(`Comment dispatch error: ${err}`));
+                break;
+            }
+            case "request_work":
+            case "question": {
+                const defaultAgent = getIssueAffinity(issue.id) ?? resolveAgentId(api);
+                api.logger.info(`Comment intent ${intentResult.intent}: routing to ${defaultAgent}`);
+                void dispatchCommentToAgent(api, linearApi, profiles, defaultAgent, issue, comment, commentBody, commentor, pluginConfig)
+                    .catch((err) => api.logger.error(`Comment dispatch error: ${err}`));
+                break;
+            }
+            case "close_issue": {
+                const closeAgent = getIssueAffinity(issue.id) ?? resolveAgentId(api);
+                api.logger.info(`Comment intent close_issue: closing ${issue.identifier ?? issue.id} via ${closeAgent}`);
+                void handleCloseIssue(api, linearApi, profiles, closeAgent, issue, comment, commentBody, commentor, pluginConfig)
+                    .catch((err) => api.logger.error(`Close issue error: ${err}`));
+                break;
+            }
+            case "general":
+            default:
+                api.logger.info(`Comment intent general: no action taken for ${issue.identifier ?? issue.id}`);
+                break;
+        }
+        return true;
+    }
+    // ── Issue.update — handle assignment/delegation to app user ──────
+    if (payload.type === "Issue" && payload.action === "update") {
+        res.statusCode = 200;
+        res.end("ok");
+        const issue = payload.data;
+        // Guard: check activeRuns FIRST (synchronous, O(1)) before any async work.
+        // Linear can send duplicate Issue.update webhooks <20ms apart for the same
+        // assignment change. Without this sync guard, both pass through the async
+        // getViewerId() call before either registers with wasRecentlyProcessed().
+        if (activeRuns.has(issue?.id)) {
+            api.logger.info(`Issue.update ${issue?.identifier ?? issue?.id}: active run — skipping`);
+            return true;
+        }
+        const updatedFrom = payload.updatedFrom ?? {};
+        // Check both assigneeId and delegateId — Linear uses delegateId for agent delegation
+        const assigneeId = issue?.assigneeId;
+        const prevAssigneeId = updatedFrom.assigneeId;
+        const delegateId = issue?.delegateId;
+        const prevDelegateId = updatedFrom.delegateId;
+        api.logger.info(`Issue.update ${issue?.identifier ?? issue?.id}: assigneeId=${assigneeId} prev=${prevAssigneeId} delegateId=${delegateId} prevDelegate=${prevDelegateId}`);
+        // Check if either assignee or delegate changed to our app user
+        const assigneeChanged = assigneeId && assigneeId !== prevAssigneeId;
+        const delegateChanged = delegateId && delegateId !== prevDelegateId;
+        if (!assigneeChanged && !delegateChanged) {
+            api.logger.info("Issue.update: no assignment/delegation change, ignoring");
+            return true;
+        }
+        const linearApi = createLinearApi(api);
+        if (!linearApi) {
+            api.logger.error("No Linear access token — cannot process issue update");
+            return true;
+        }
+        const viewerId = await linearApi.getViewerId();
+        const isAssignedToUs = assigneeChanged && assigneeId === viewerId;
+        const isDelegatedToUs = delegateChanged && delegateId === viewerId;
+        if (!isAssignedToUs && !isDelegatedToUs) {
+            api.logger.info(`Issue.update: assignee=${assigneeId} delegate=${delegateId}, not us (${viewerId}), ignoring`);
+            return true;
+        }
+        const trigger = isDelegatedToUs ? "delegated" : "assigned";
+        api.logger.info(`Issue ${trigger} to our app user (${viewerId}), executing pipeline`);
+        // Secondary dedup: catch duplicate webhooks that both passed the activeRuns
+        // check before either could register (belt-and-suspenders with the sync guard).
+        const dedupKey = `${trigger}:${issue.id}:${viewerId}`;
+        if (wasRecentlyProcessed(dedupKey)) {
+            api.logger.info(`${trigger} ${issue.id} -> ${viewerId} already processed — skipping`);
+            return true;
+        }
+        // Assignment triggers the full dispatch pipeline:
+        // tier assessment → worktree → plan → implement → audit
+        void handleDispatch(api, linearApi, issue).catch((err) => {
+            api.logger.error(`Dispatch pipeline error for ${issue.identifier ?? issue.id}: ${err}`);
+        });
+        return true;
+    }
+    // ── Issue.create — auto-triage new issues ───────────────────────
+    if (payload.type === "Issue" && payload.action === "create") {
+        res.statusCode = 200;
+        res.end("ok");
+        const issue = payload.data;
+        if (!issue?.id) {
+            api.logger.error("Issue.create missing issue data");
+            return true;
+        }
+        // Dedup
+        if (wasRecentlyProcessed(`issue-create:${issue.id}`)) {
+            api.logger.info(`Issue.create ${issue.id} already processed — skipping`);
+            return true;
+        }
+        api.logger.info(`Issue.create: ${issue.identifier ?? issue.id} — ${issue.title ?? "(untitled)"}`);
+        const pluginConfig = api.pluginConfig;
+        const linearApi = createLinearApi(api);
+        if (!linearApi) {
+            api.logger.error("No Linear access token — cannot triage new issue");
+            return true;
+        }
+        // Validate agent profiles
+        const profilesError = validateProfiles();
+        if (profilesError) {
+            api.logger.error("Agent profiles validation failed — cannot triage new issue");
+            try {
+                await createCommentWithDedup(linearApi, issue.id, profilesError);
+            }
+            catch { }
+            return true;
+        }
+        const agentId = resolveAgentId(api);
+        // Guard: prevent duplicate runs on same issue (also blocks AgentSessionEvent
+        // webhooks that arrive from sessions we create during triage)
+        if (activeRuns.has(issue.id)) {
+            api.logger.info(`Issue.create: ${issue.identifier ?? issue.id} already has active run — skipping triage`);
+            return true;
+        }
+        activeRuns.add(issue.id);
+        // Dispatch triage (non-blocking)
+        void (async () => {
+            const profiles = loadAgentProfiles();
+            const label = profiles[agentId]?.label ?? agentId;
+            const avatarUrl = profiles[agentId]?.avatarUrl;
+            let agentSessionId = null;
+            try {
+                // Fetch enriched issue + team labels
+                let enrichedIssue = issue;
+                let teamLabels = [];
+                try {
+                    enrichedIssue = await linearApi.getIssueDetails(issue.id);
+                    if (enrichedIssue?.team?.id) {
+                        teamLabels = await linearApi.getTeamLabels(enrichedIssue.team.id);
+                    }
+                }
+                catch (err) {
+                    api.logger.warn(`Could not fetch issue details for triage: ${err}`);
+                }
+                // Skip triage for issues in projects that are actively being planned —
+                // the planner creates issues and triage would overwrite its estimates/labels.
+                const triageProjectId = enrichedIssue?.project?.id;
+                if (triageProjectId) {
+                    const planStatePath = pluginConfig?.planningStatePath;
+                    try {
+                        const planState = await readPlanningState(planStatePath);
+                        if (isInPlanningMode(planState, triageProjectId)) {
+                            api.logger.info(`Issue.create: ${issue.identifier ?? issue.id} belongs to project in planning mode — skipping triage`);
+                            return;
+                        }
+                    }
+                    catch { /* proceed with triage if planning state check fails */ }
+                }
+                // Skip triage for issues created by our own bot user
+                const viewerId = await linearApi.getViewerId();
+                if (viewerId && issue.creatorId === viewerId) {
+                    api.logger.info(`Issue.create: ${issue.identifier ?? issue.id} created by our bot — skipping triage`);
+                    return;
+                }
+                const description = enrichedIssue?.description ?? issue?.description ?? "(no description)";
+                const estimationType = enrichedIssue?.team?.issueEstimationType ?? "fibonacci";
+                const currentLabels = enrichedIssue?.labels?.nodes ?? [];
+                const currentLabelNames = currentLabels.map((l) => l.name).join(", ") || "None";
+                const availableLabelList = teamLabels.map((l) => `  - "${l.name}" (id: ${l.id})`).join("\n");
+                // Create agent session
+                const sessionResult = await linearApi.createSessionOnIssue(issue.id);
+                agentSessionId = sessionResult.sessionId;
+                if (agentSessionId) {
+                    wasRecentlyProcessed(`session:${agentSessionId}`);
+                    api.logger.info(`Created agent session ${agentSessionId} for Issue.create triage`);
+                    setActiveSession({
+                        agentSessionId,
+                        issueIdentifier: enrichedIssue?.identifier ?? issue.identifier ?? issue.id,
+                        issueId: issue.id,
+                        agentId,
+                        startedAt: Date.now(),
+                    });
+                }
+                if (agentSessionId) {
+                    await linearApi.emitActivity(agentSessionId, {
+                        type: "thought",
+                        body: `${label} is triaging new issue ${enrichedIssue?.identifier ?? issue.id}...`,
+                    }).catch(() => { });
+                }
+                if (agentSessionId) {
+                    await linearApi.emitActivity(agentSessionId, {
+                        type: "action",
+                        action: "Triaging",
+                        parameter: `${enrichedIssue?.identifier ?? issue.id} — estimating, labeling`,
+                    }).catch(() => { });
+                }
+                const creatorName = enrichedIssue?.creator?.name ?? "Unknown";
+                const creatorEmail = enrichedIssue?.creator?.email ?? null;
+                const creatorLine = creatorEmail
+                    ? `**Created by:** ${creatorName} (${creatorEmail})`
+                    : `**Created by:** ${creatorName}`;
+                // Look up cached guidance for triage
+                const triageTeamId = enrichedIssue?.team?.id ?? issue?.team?.id;
+                const triageGuidance = triageTeamId ? getCachedGuidanceForTeam(triageTeamId) : null;
+                const triageGuidanceAppendix = isGuidanceEnabled(pluginConfig, triageTeamId)
+                    ? formatGuidanceAppendix(triageGuidance)
+                    : "";
+                const projectCtx = buildProjectContext(pluginConfig);
+                const message = [
+                    `IMPORTANT: You are triaging a new Linear issue. You MUST respond with a JSON block containing your triage decisions, followed by your assessment as plain text.`,
+                    ``,
+                    `## Issue: ${enrichedIssue?.identifier ?? issue.identifier ?? issue.id} — ${enrichedIssue?.title ?? issue.title ?? "(untitled)"}`,
+                    `**Status:** ${enrichedIssue?.state?.name ?? "Unknown"} | **Current Estimate:** ${enrichedIssue?.estimate ?? "None"} | **Current Labels:** ${currentLabelNames}`,
+                    creatorLine,
+                    ``,
+                    `**Description:**`,
+                    description,
+                    ``,
+                    ...(projectCtx ? [projectCtx, ``] : []),
+                    `## Your Triage Tasks`,
+                    ``,
+                    `1. **Story Points** — Estimate complexity using ${estimationType} scale (1=trivial, 2=small, 3=medium, 5=large, 8=very large, 13=epic)`,
+                    `2. **Labels** — Select appropriate labels from the team's available labels`,
+                    `3. **Priority** — Set priority (1=Urgent, 2=High, 3=Medium, 4=Low) if not already set`,
+                    `4. **Assessment** — Brief analysis of what this issue needs`,
+                    ``,
+                    `## Available Labels`,
+                    availableLabelList || "  (no labels configured)",
+                    ``,
+                    `## Response Format`,
+                    ``,
+                    `You MUST start your response with a JSON block, then follow with your assessment:`,
+                    ``,
+                    '```json',
+                    `{`,
+                    `  "estimate": <number>,`,
+                    `  "labelIds": ["<id1>", "<id2>"],`,
+                    `  "priority": <number or null>,`,
+                    `  "assessment": "<one-line summary of your sizing rationale>"`,
+                    `}`,
+                    '```',
+                    ``,
+                    `IMPORTANT: Only reference real users from the issue data above. Do NOT fabricate or guess user names, emails, or identities. The issue creator is shown in the "Created by" field.`,
+                    ``,
+                    `Then write your full assessment as markdown below the JSON block.`,
+                    triageGuidanceAppendix,
+                ].filter(Boolean).join("\n");
+                const sessionId = `linear-triage-${issue.id}-${Date.now()}`;
+                const { runAgent } = await import("../agent/agent.js");
+                const result = await runAgent({
+                    api,
+                    agentId,
+                    sessionId,
+                    message,
+                    timeoutMs: 3 * 60_000,
+                    streaming: agentSessionId ? { linearApi, agentSessionId } : undefined,
+                    // Triage is strictly read-only: the agent can read/search the
+                    // codebase but all write-capable tools are denied via config
+                    // policy.  The only artifacts are a Linear comment + issue updates.
+                    readOnly: true,
+                });
+                const responseBody = result.success
+                    ? result.output
+                    : `Something went wrong while triaging this issue. You may need to set the estimate and labels manually.`;
+                // Parse triage JSON and apply to issue
+                let commentBody = responseBody;
+                if (result.success) {
+                    const jsonMatch = responseBody.match(/```json\s*\n?([\s\S]*?)\n?```/);
+                    if (jsonMatch) {
+                        try {
+                            const triage = JSON.parse(jsonMatch[1]);
+                            const updateInput = {};
+                            if (typeof triage.estimate === "number") {
+                                updateInput.estimate = triage.estimate;
+                            }
+                            if (Array.isArray(triage.labelIds) && triage.labelIds.length > 0) {
+                                const existingIds = currentLabels.map((l) => l.id);
+                                const allIds = [...new Set([...existingIds, ...triage.labelIds])];
+                                updateInput.labelIds = allIds;
+                            }
+                            if (typeof triage.priority === "number" && triage.priority >= 1 && triage.priority <= 4) {
+                                updateInput.priority = triage.priority;
+                            }
+                            if (Object.keys(updateInput).length > 0) {
+                                await linearApi.updateIssue(issue.id, updateInput);
+                                api.logger.info(`Applied triage to ${enrichedIssue?.identifier ?? issue.id}: ${JSON.stringify(updateInput)}`);
+                                if (agentSessionId) {
+                                    await linearApi.emitActivity(agentSessionId, {
+                                        type: "action",
+                                        action: "Applied triage",
+                                        result: `estimate=${triage.estimate ?? "unchanged"}, labels=${triage.labelIds?.length ?? 0}, priority=${triage.priority ?? "unchanged"}`,
+                                    }).catch(() => { });
+                                }
+                            }
+                            // Strip JSON block from comment
+                            commentBody = responseBody.replace(/```json\s*\n?[\s\S]*?\n?```\s*\n?/, "").trim();
+                        }
+                        catch (parseErr) {
+                            api.logger.warn(`Could not parse triage JSON: ${parseErr}`);
+                        }
+                    }
+                }
+                // When a session exists, prefer emitActivity (avoids duplicate comment).
+                // Otherwise, post as a regular comment.
+                if (agentSessionId) {
+                    const labeledComment = `**[${label}]** ${commentBody}`;
+                    const emitted = await linearApi.emitActivity(agentSessionId, {
+                        type: "response",
+                        body: labeledComment,
+                    }).then(() => true).catch(() => false);
+                    if (!emitted) {
+                        const agentOpts = avatarUrl
+                            ? { createAsUser: label, displayIconUrl: avatarUrl }
+                            : undefined;
+                        await postAgentComment(api, linearApi, issue.id, commentBody, label, agentOpts);
+                    }
+                }
+                else {
+                    const agentOpts = avatarUrl
+                        ? { createAsUser: label, displayIconUrl: avatarUrl }
+                        : undefined;
+                    await postAgentComment(api, linearApi, issue.id, commentBody, label, agentOpts);
+                }
+                api.logger.info(`Triage complete for ${enrichedIssue?.identifier ?? issue.id}`);
+            }
+            catch (err) {
+                api.logger.error(`Issue.create triage error: ${err}`);
+                if (agentSessionId) {
+                    await linearApi.emitActivity(agentSessionId, {
+                        type: "error",
+                        body: `Failed to triage: ${String(err).slice(0, 500)}`,
+                    }).catch(() => { });
+                }
+            }
+            finally {
+                clearActiveSession(issue.id);
+                activeRuns.delete(issue.id);
+            }
+        })();
+        return true;
+    }
+    // ── Default: log unhandled webhook types for debugging ──────────
+    api.logger.warn(`Unhandled webhook type=${payload.type} action=${payload.action} — payload: ${JSON.stringify(payload).slice(0, 500)}`);
+    res.statusCode = 200;
+    res.end("ok");
+    return true;
+}
+// ── Comment dispatch helper ───────────────────────────────────────
+//
+// Dispatches a comment to a specific agent. Used by intent-based routing
+// and @mention fast path.
+async function dispatchCommentToAgent(api, linearApi, profiles, agentId, issue, comment, commentBody, commentor, pluginConfig) {
+    const profile = profiles[agentId];
+    const label = profile?.label ?? agentId;
+    const avatarUrl = profile?.avatarUrl;
+    // Guard: prevent concurrent runs on same issue
+    if (activeRuns.has(issue.id)) {
+        api.logger.info(`dispatchCommentToAgent: ${issue.identifier ?? issue.id} has active run — skipping`);
+        return;
+    }
+    // Fetch full issue details
+    let enrichedIssue = issue;
+    try {
+        enrichedIssue = await linearApi.getIssueDetails(issue.id);
+    }
+    catch (err) {
+        api.logger.warn(`Could not fetch issue details: ${err}`);
+    }
+    const description = enrichedIssue?.description ?? issue?.description ?? "(no description)";
+    const comments = enrichedIssue?.comments?.nodes ?? [];
+    const commentSummary = comments
+        .slice(-5)
+        .map((c) => `**${c.user?.name ?? "Unknown"}**: ${(c.body ?? "").slice(0, 200)}`)
+        .join("\n");
+    // Look up cached guidance for this team (Comment webhooks don't carry guidance)
+    const commentTeamId = enrichedIssue?.team?.id;
+    const cachedGuidance = commentTeamId ? getCachedGuidanceForTeam(commentTeamId) : null;
+    const commentGuidanceAppendix = isGuidanceEnabled(pluginConfig, commentTeamId)
+        ? formatGuidanceAppendix(cachedGuidance)
+        : "";
+    const issueRef = enrichedIssue?.identifier ?? issue.identifier ?? issue.id;
+    const stateType = enrichedIssue?.state?.type ?? "";
+    const isTriaged = stateType === "started" || stateType === "completed" || stateType === "canceled";
+    const cliTool = resolveToolName(loadCodingConfig(), agentId);
+    const toolAccessLines = isTriaged
+        ? [
+            `**Tool access:**`,
+            `- \`linear_issues\` tool: Full access. Use action="read" with issueId="${issueRef}" to get details, action="create" to create issues (with parentIssueId to create sub-issues for granular work breakdown), action="update" with status/priority/labels/estimate to modify issues, action="comment" to post comments, action="list_states" to see available workflow states.`,
+            `- \`${cliTool}\`: Dispatch coding work to a worker. Workers return text — they cannot access linear_issues.`,
+            `- Standard tools: exec, read, edit, write, web_search, etc.`,
+            ``,
+            `**Sub-issue guidance:** When a task is too large or has multiple distinct parts, break it into sub-issues using action="create" with parentIssueId="${issueRef}". Each sub-issue should be an atomic, independently testable unit of work with its own acceptance criteria. This enables parallel dispatch and clearer progress tracking.`,
+        ]
+        : [
+            `**Tool access:**`,
+            `- \`linear_issues\` tool: READ ONLY. Use action="read" with issueId="${issueRef}" to get details, action="list_states"/"list_labels" for metadata. Do NOT use action="update", action="create", or action="comment".`,
+            `- \`${cliTool}\`: **Planning mode only.** Workers may explore code and write plan files (PLAN.md, design docs). Workers MUST NOT create, modify, or delete source code, run deployments, or make system changes. Use for codebase exploration and planning only.`,
+            `- Standard tools: exec, read, edit, write, web_search, etc.`,
+        ];
+    const roleLines = isTriaged
+        ? [`**Your role:** Orchestrator with full Linear access. You can update issue fields, change status, and dispatch work via \`${cliTool}\`. Do NOT post comments yourself — the handler posts your text output.`]
+        : [`**Your role:** Dispatcher. For work requests, use \`${cliTool}\`. You do NOT update issue status — the audit system handles lifecycle.`];
+    const message = [
+        `You are an orchestrator responding to a Linear comment. Your text output will be automatically posted as a comment on the issue (do NOT post a comment yourself — the handler does it).`,
+        ``,
+        ...toolAccessLines,
+        ``,
+        ...roleLines,
+        ``,
+        `## Issue: ${issueRef} — ${enrichedIssue?.title ?? issue.title ?? "(untitled)"}`,
+        `**Status:** ${enrichedIssue?.state?.name ?? "Unknown"} | **Assignee:** ${enrichedIssue?.assignee?.name ?? "Unassigned"}`,
+        enrichedIssue?.creator ? `**Created by:** ${enrichedIssue.creator.name}${enrichedIssue.creator.email ? ` (${enrichedIssue.creator.email})` : ""}` : "",
+        ``,
+        `**Description:**`,
+        description,
+        commentSummary ? `\n**Recent comments:**\n${commentSummary}` : "",
+        `\n**${commentor} says:**\n> ${commentBody}`,
+        ``,
+        `IMPORTANT: Only reference real users from the issue data above. Do NOT fabricate or guess user names, emails, or identities.`,
+        ``,
+        `## Scope Rules`,
+        `1. **Read the issue first.** The issue title + description define your scope. Everything you do must serve the issue as written.`,
+        `2. **\`${cliTool}\` is ONLY for issue-body work.** Only dispatch \`${cliTool}\` when the issue description contains implementation requirements. A greeting, question, or conversational issue gets a conversational response — NOT ${cliTool}.`,
+        `3. **Comments explore, issue body builds.** The comment above may explore scope or ask questions but NEVER trigger \`${cliTool}\` from a comment alone. If the comment requests new implementation, suggest updating the issue description or creating a new issue.`,
+        `4. **Plan before building.** For non-trivial work, respond with a plan first. Only dispatch \`${cliTool}\` after the plan is clear and grounded in the issue body.`,
+        `5. **Match response to request.** Greeting → greet. Question → answer. No implementation requirements in the issue body → no ${cliTool}.`,
+        ``,
+        `Respond within the scope defined above. Be concise and action-oriented.`,
+        commentGuidanceAppendix,
+    ].filter(Boolean).join("\n");
+    // Dispatch with session lifecycle
+    activeRuns.add(issue.id);
+    let agentSessionId = null;
+    try {
+        // Create agent session (non-fatal)
+        const sessionResult = await linearApi.createSessionOnIssue(issue.id);
+        agentSessionId = sessionResult.sessionId;
+        if (agentSessionId) {
+            wasRecentlyProcessed(`session:${agentSessionId}`);
+            setActiveSession({
+                agentSessionId,
+                issueIdentifier: enrichedIssue?.identifier ?? issue.identifier ?? issue.id,
+                issueId: issue.id,
+                agentId,
+                startedAt: Date.now(),
+            });
+        }
+        // Emit thought — include comment excerpt so the user sees immediate context
+        if (agentSessionId) {
+            const excerpt = commentBody.length > 200 ? commentBody.slice(0, 200) + "..." : commentBody;
+            await linearApi.emitActivity(agentSessionId, {
+                type: "thought",
+                body: `${label} received comment on ${issueRef}: "${excerpt}" — working on it now...`,
+            }).catch(() => { });
+        }
+        // Run agent
+        const sessionId = `linear-comment-${agentId}-${Date.now()}`;
+        const { runAgent } = await import("../agent/agent.js");
+        const result = await runAgent({
+            api,
+            agentId,
+            sessionId,
+            message,
+            timeoutMs: 3 * 60_000,
+            streaming: agentSessionId ? { linearApi, agentSessionId } : undefined,
+        });
+        const responseBody = result.success
+            ? result.output
+            : `Something went wrong while processing this. The system will retry automatically if possible.`;
+        // When a session exists, prefer emitActivity (avoids duplicate comment).
+        // Otherwise, post as a regular comment.
+        if (agentSessionId) {
+            const labeledResponse = `**[${label}]** ${responseBody}`;
+            const emitted = await linearApi.emitActivity(agentSessionId, {
+                type: "response",
+                body: labeledResponse,
+            }).then(() => true).catch(() => false);
+            if (!emitted) {
+                const agentOpts = avatarUrl
+                    ? { createAsUser: label, displayIconUrl: avatarUrl }
+                    : undefined;
+                await postAgentComment(api, linearApi, issue.id, responseBody, label, agentOpts);
+            }
+        }
+        else {
+            const agentOpts = avatarUrl
+                ? { createAsUser: label, displayIconUrl: avatarUrl }
+                : undefined;
+            await postAgentComment(api, linearApi, issue.id, responseBody, label, agentOpts);
+        }
+        api.logger.info(`Posted ${agentId} response to ${issueRef}`);
+    }
+    catch (err) {
+        api.logger.error(`dispatchCommentToAgent error: ${err}`);
+        if (agentSessionId) {
+            await linearApi.emitActivity(agentSessionId, {
+                type: "error",
+                body: `Failed to process comment: ${String(err).slice(0, 500)}`,
+            }).catch(() => { });
+        }
+    }
+    finally {
+        clearActiveSession(issue.id);
+        activeRuns.delete(issue.id);
+    }
+}
+// ── Close issue handler ──────────────────────────────────────────
+//
+// Triggered by close_issue intent. Generates a closure report via agent,
+// transitions issue to completed state, and posts the report.
+async function handleCloseIssue(api, linearApi, profiles, agentId, issue, comment, commentBody, commentor, pluginConfig) {
+    const profile = profiles[agentId];
+    const label = profile?.label ?? agentId;
+    const avatarUrl = profile?.avatarUrl;
+    if (activeRuns.has(issue.id)) {
+        api.logger.info(`handleCloseIssue: ${issue.identifier ?? issue.id} has active run — skipping`);
+        return;
+    }
+    // Fetch full issue details
+    let enrichedIssue = issue;
+    try {
+        enrichedIssue = await linearApi.getIssueDetails(issue.id);
+    }
+    catch (err) {
+        api.logger.warn(`Could not fetch issue details for close: ${err}`);
+    }
+    const issueRef = enrichedIssue?.identifier ?? issue.identifier ?? issue.id;
+    const teamId = enrichedIssue?.team?.id ?? issue.team?.id;
+    // Find completed state
+    let completedStateId = null;
+    if (teamId) {
+        try {
+            const states = await linearApi.getTeamStates(teamId);
+            const completedState = states.find((s) => s.type === "completed");
+            if (completedState)
+                completedStateId = completedState.id;
+        }
+        catch (err) {
+            api.logger.warn(`Could not fetch team states for close: ${err}`);
+        }
+    }
+    // Build closure report prompt
+    const description = enrichedIssue?.description ?? issue?.description ?? "(no description)";
+    const comments = enrichedIssue?.comments?.nodes ?? [];
+    const commentSummary = comments
+        .slice(-10)
+        .map((c) => `**${c.user?.name ?? "Unknown"}**: ${(c.body ?? "").slice(0, 300)}`)
+        .join("\n");
+    // Look up cached guidance
+    const closeGuidance = teamId ? getCachedGuidanceForTeam(teamId) : null;
+    const closeGuidanceAppendix = isGuidanceEnabled(pluginConfig, teamId)
+        ? formatGuidanceAppendix(closeGuidance)
+        : "";
+    const message = [
+        `You are writing a closure report for a Linear issue that is being marked as done.`,
+        `Your text output will be posted as the closing comment on the issue.`,
+        ``,
+        `## Issue: ${issueRef} — ${enrichedIssue?.title ?? issue.title ?? "(untitled)"}`,
+        `**Status:** ${enrichedIssue?.state?.name ?? "Unknown"} | **Assignee:** ${enrichedIssue?.assignee?.name ?? "Unassigned"}`,
+        enrichedIssue?.creator ? `**Created by:** ${enrichedIssue.creator.name}${enrichedIssue.creator.email ? ` (${enrichedIssue.creator.email})` : ""}` : "",
+        ``,
+        `**Description:**`,
+        description,
+        commentSummary ? `\n**Comment history:**\n${commentSummary}` : "",
+        `\n**${commentor} says (closure request):**\n> ${commentBody}`,
+        ``,
+        `IMPORTANT: Only reference real users from the issue data above. Do NOT fabricate or guess user names, emails, or identities.`,
+        ``,
+        `Write a concise closure report with:`,
+        `- **Summary**: What was done (1-2 sentences)`,
+        `- **Resolution**: How it was resolved`,
+        `- **Notes**: Any follow-up items or caveats (if applicable)`,
+        ``,
+        `Keep it brief and factual. Use markdown formatting.`,
+        closeGuidanceAppendix,
+    ].filter(Boolean).join("\n");
+    // Execute with session lifecycle
+    activeRuns.add(issue.id);
+    let agentSessionId = null;
+    try {
+        const sessionResult = await linearApi.createSessionOnIssue(issue.id);
+        agentSessionId = sessionResult.sessionId;
+        if (agentSessionId) {
+            wasRecentlyProcessed(`session:${agentSessionId}`);
+            setActiveSession({
+                agentSessionId,
+                issueIdentifier: issueRef,
+                issueId: issue.id,
+                agentId,
+                startedAt: Date.now(),
+            });
+        }
+        if (agentSessionId) {
+            await linearApi.emitActivity(agentSessionId, {
+                type: "thought",
+                body: `${label} is preparing closure report for ${issueRef}...`,
+            }).catch(() => { });
+        }
+        // Run agent for closure report
+        const { runAgent } = await import("../agent/agent.js");
+        const result = await runAgent({
+            api,
+            agentId,
+            sessionId: `linear-close-${agentId}-${Date.now()}`,
+            message,
+            timeoutMs: 2 * 60_000,
+            readOnly: true,
+        });
+        if (!result.success) {
+            api.logger.error(`Closure report agent failed for ${issueRef}: ${(result.output ?? "no output").slice(0, 500)}`);
+        }
+        const closureReport = result.success
+            ? result.output
+            : `Issue closed by ${commentor}.\n\n> ${commentBody}\n\n*Closure report generation failed — agent returned: ${(result.output ?? "no output").slice(0, 200)}*`;
+        const fullReport = `## Closure Report\n\n${closureReport}`;
+        // Transition issue to completed state
+        if (completedStateId) {
+            try {
+                await linearApi.updateIssue(issue.id, { stateId: completedStateId });
+                api.logger.info(`Closed issue ${issueRef} (state → completed)`);
+            }
+            catch (err) {
+                api.logger.error(`Failed to transition issue ${issueRef} to completed: ${err}`);
+            }
+        }
+        else {
+            api.logger.warn(`No completed state found for ${issueRef} — posting report without state change`);
+        }
+        // Post closure report via emitActivity-first pattern
+        if (agentSessionId) {
+            const labeledReport = `**[${label}]** ${fullReport}`;
+            const emitted = await linearApi.emitActivity(agentSessionId, {
+                type: "response",
+                body: labeledReport,
+            }).then(() => true).catch(() => false);
+            if (!emitted) {
+                const agentOpts = avatarUrl
+                    ? { createAsUser: label, displayIconUrl: avatarUrl }
+                    : undefined;
+                await postAgentComment(api, linearApi, issue.id, fullReport, label, agentOpts);
+            }
+        }
+        else {
+            const agentOpts = avatarUrl
+                ? { createAsUser: label, displayIconUrl: avatarUrl }
+                : undefined;
+            await postAgentComment(api, linearApi, issue.id, fullReport, label, agentOpts);
+        }
+        api.logger.info(`Posted closure report for ${issueRef}`);
+    }
+    catch (err) {
+        api.logger.error(`handleCloseIssue error: ${err}`);
+        if (agentSessionId) {
+            await linearApi.emitActivity(agentSessionId, {
+                type: "error",
+                body: `Failed to close issue: ${String(err).slice(0, 500)}`,
+            }).catch(() => { });
+        }
+    }
+    finally {
+        clearActiveSession(issue.id);
+        activeRuns.delete(issue.id);
+    }
+}
+// ── @dispatch handler ─────────────────────────────────────────────
+//
+// Triggered by `@dispatch` in a Linear comment. Assesses issue complexity,
+// creates a persistent worktree, registers the dispatch in state, and
+// launches the pipeline (plan → implement → audit).
+async function handleDispatch(api, linearApi, issue) {
+    const pluginConfig = api.pluginConfig;
+    const statePath = pluginConfig?.dispatchStatePath;
+    const worktreeBaseDir = pluginConfig?.worktreeBaseDir;
+    const baseRepo = pluginConfig?.codexBaseRepo ?? join(process.env.HOME ?? homedir(), "ai-workspace");
+    const identifier = issue.identifier ?? issue.id;
+    api.logger.info(`@dispatch: processing ${identifier}`);
+    // 0. Check planning mode — prevent dispatch for issues in planning-mode projects
+    try {
+        const enrichedForPlan = await linearApi.getIssueDetails(issue.id ?? issue);
+        const planProjectId = enrichedForPlan?.project?.id;
+        if (planProjectId) {
+            const planStatePath = pluginConfig?.planningStatePath;
+            const planState = await readPlanningState(planStatePath);
+            if (isInPlanningMode(planState, planProjectId)) {
+                api.logger.info(`dispatch: ${identifier} is in planning-mode project — skipping`);
+                await createCommentWithDedup(linearApi, issue.id, `**Can't dispatch yet** — this project is in planning mode.\n\n**To continue:** Comment on the planning issue with your requirements, then say **"finalize plan"** when ready.\n\n**To cancel planning:** Comment **"abandon"** on the planning issue.`);
+                return;
+            }
+        }
+    }
+    catch (err) {
+        api.logger.warn(`dispatch: planning mode check failed for ${identifier}: ${err}`);
+    }
+    // 1. Check for existing active dispatch — reclaim if stale
+    const STALE_DISPATCH_MS = 30 * 60_000; // 30 min without a gateway holding it = stale
+    const state = await readDispatchState(statePath);
+    const existing = getActiveDispatch(state, identifier);
+    if (existing) {
+        const ageMs = Date.now() - new Date(existing.dispatchedAt).getTime();
+        const isStale = ageMs > STALE_DISPATCH_MS;
+        const inMemory = activeRuns.has(issue.id);
+        if (!isStale && inMemory) {
+            // Truly still running in this gateway process
+            api.logger.info(`dispatch: ${identifier} actively running (status: ${existing.status}, age: ${Math.round(ageMs / 1000)}s) — skipping`);
+            await createCommentWithDedup(linearApi, issue.id, `**Already running** as **${existing.tier}** — status: **${existing.status}**, started ${Math.round(ageMs / 60_000)}m ago.\n\nWorktree: \`${existing.worktreePath}\`\n\n**Options:**\n- Check progress: \`/dispatch status ${identifier}\`\n- Force restart: \`/dispatch retry ${identifier}\` (only works when stuck)\n- Escalate: \`/dispatch escalate ${identifier} "reason"\``);
+            return;
+        }
+        // Stale or not in memory (gateway restarted) — reclaim
+        api.logger.info(`dispatch: ${identifier} reclaiming stale dispatch (status: ${existing.status}, ` +
+            `age: ${Math.round(ageMs / 1000)}s, inMemory: ${inMemory}, stale: ${isStale})`);
+        await removeActiveDispatch(identifier, statePath);
+        activeRuns.delete(issue.id);
+    }
+    // 2. Prevent concurrent runs on same issue
+    if (activeRuns.has(issue.id)) {
+        api.logger.info(`@dispatch: ${identifier} has active agent run — skipping`);
+        return;
+    }
+    // 3. Fetch full issue details for tier assessment
+    let enrichedIssue;
+    try {
+        enrichedIssue = await linearApi.getIssueDetails(issue.id);
+    }
+    catch (err) {
+        api.logger.error(`@dispatch: failed to fetch issue details: ${err}`);
+        enrichedIssue = issue;
+    }
+    const labels = enrichedIssue.labels?.nodes?.map((l) => l.name) ?? [];
+    const commentCount = enrichedIssue.comments?.nodes?.length ?? 0;
+    const dispatchTeamKey = enrichedIssue?.team?.key;
+    // Resolve repos for this dispatch (issue body markers → labels → team mapping → config default)
+    const repoResolution = resolveRepos(enrichedIssue.description, labels, pluginConfig, dispatchTeamKey);
+    api.logger.info(`@dispatch: ${identifier} team=${dispatchTeamKey ?? "none"} repos=${repoResolution.repos.map(r => r.name).join(",")} source=${repoResolution.source}`);
+    // 4. Assess complexity tier
+    const assessment = await assessTier(api, {
+        identifier,
+        title: enrichedIssue.title ?? "(untitled)",
+        description: enrichedIssue.description,
+        labels,
+        commentCount,
+    });
+    api.logger.info(`@dispatch: ${identifier} assessed as ${assessment.tier} (${assessment.model}) — ${assessment.reasoning}`);
+    emitDiagnostic(api, {
+        event: "dispatch_started",
+        identifier,
+        tier: assessment.tier,
+        issueId: issue.id,
+        agentId: resolveAgentId(api),
+    });
+    // 5. Create persistent worktree(s)
+    let worktreePath;
+    let worktreeBranch;
+    let worktreeResumed;
+    let worktrees;
+    try {
+        if (isMultiRepo(repoResolution)) {
+            const multi = createMultiWorktree(identifier, repoResolution.repos, { baseDir: worktreeBaseDir });
+            worktreePath = multi.parentPath;
+            worktreeBranch = `codex/${identifier}`;
+            worktreeResumed = multi.worktrees.some(w => w.resumed);
+            worktrees = multi.worktrees.map(w => ({ repoName: w.repoName, path: w.path, branch: w.branch }));
+            api.logger.info(`@dispatch: multi-repo worktrees ${worktreeResumed ? "resumed" : "created"} at ${worktreePath} (${repoResolution.repos.map(r => r.name).join(", ")})`);
+        }
+        else {
+            const single = createWorktree(identifier, { baseRepo, baseDir: worktreeBaseDir });
+            worktreePath = single.path;
+            worktreeBranch = single.branch;
+            worktreeResumed = single.resumed;
+            api.logger.info(`@dispatch: worktree ${worktreeResumed ? "resumed" : "created"} at ${worktreePath}`);
+        }
+    }
+    catch (err) {
+        api.logger.error(`@dispatch: worktree creation failed: ${err}`);
+        await createCommentWithDedup(linearApi, issue.id, `**Dispatch failed** — couldn't create the worktree.\n\n> ${String(err).slice(0, 200)}\n\n**What to try:**\n- Check that the base repo exists\n- Re-assign this issue to try again\n- Check logs: \`journalctl --user -u openclaw-gateway --since "5 min ago"\``);
+        return;
+    }
+    // 5b. Prepare workspace(s)
+    if (worktrees) {
+        for (const wt of worktrees) {
+            const prep = prepareWorkspace(wt.path, wt.branch);
+            if (prep.errors.length > 0) {
+                api.logger.warn(`@dispatch: workspace prep for ${wt.repoName} had errors: ${prep.errors.join("; ")}`);
+            }
+        }
+    }
+    else {
+        const prep = prepareWorkspace(worktreePath, worktreeBranch);
+        if (prep.errors.length > 0) {
+            api.logger.warn(`@dispatch: workspace prep had errors: ${prep.errors.join("; ")}`);
+        }
+        else {
+            api.logger.info(`@dispatch: workspace prepared — pulled=${prep.pulled}, submodules=${prep.submodulesInitialized}`);
+        }
+    }
+    // 6. Create agent session on Linear
+    // Mark active BEFORE session creation so that any AgentSessionEvent.created
+    // webhook arriving from this call is blocked by the activeRuns guard.
+    activeRuns.add(issue.id);
+    let agentSessionId;
+    try {
+        const sessionResult = await linearApi.createSessionOnIssue(issue.id);
+        agentSessionId = sessionResult.sessionId ?? undefined;
+    }
+    catch (err) {
+        api.logger.warn(`@dispatch: could not create agent session: ${err}`);
+    }
+    // 6b. Initialize .claw/ artifact directory
+    try {
+        ensureClawDir(worktreePath);
+        writeManifest(worktreePath, {
+            issueIdentifier: identifier,
+            issueTitle: enrichedIssue.title ?? "(untitled)",
+            issueId: issue.id,
+            tier: assessment.tier,
+            model: assessment.model,
+            dispatchedAt: new Date().toISOString(),
+            worktreePath,
+            branch: worktreeBranch,
+            attempts: 0,
+            status: "dispatched",
+            plugin: "openclaw-linear",
+        });
+    }
+    catch (err) {
+        api.logger.warn(`@dispatch: .claw/ init failed: ${err}`);
+    }
+    // 7. Register dispatch in persistent state, then bridge into the
+    // openclaw runtime task-flow registry so the dispatch shows up alongside
+    // any other durable agent work in the gateway's task surface.
+    const now = new Date().toISOString();
+    const initialDispatch = {
+        issueId: issue.id,
+        issueIdentifier: identifier,
+        issueTitle: enrichedIssue.title ?? "(untitled)",
+        worktreePath,
+        branch: worktreeBranch,
+        tier: assessment.tier,
+        model: assessment.model,
+        status: "dispatched",
+        dispatchedAt: now,
+        agentSessionId,
+        attempt: 0,
+        project: enrichedIssue?.project?.id,
+        worktrees,
+    };
+    const dispatchWithFlow = createManagedFlowForDispatch(api, initialDispatch);
+    await registerDispatch(identifier, dispatchWithFlow, statePath);
+    // 7b. Linear state transition: set issue to "In Progress" (best-effort)
+    if (enrichedIssue?.team?.id) {
+        try {
+            const teamStates = await linearApi.getTeamStates(enrichedIssue.team.id);
+            const inProgress = teamStates.find((s) => s.type === "started");
+            if (inProgress) {
+                await linearApi.updateIssue(issue.id, { stateId: inProgress.id });
+                api.logger.info(`@dispatch: ${identifier} → ${inProgress.name} (In Progress)`);
+            }
+        }
+        catch (err) {
+            api.logger.warn(`@dispatch: ${identifier} — failed to set In Progress state: ${err}`);
+        }
+    }
+    // 8. Register active session for tool resolution
+    setActiveSession({
+        agentSessionId: agentSessionId ?? "",
+        issueIdentifier: identifier,
+        issueId: issue.id,
+        agentId: resolveAgentId(api),
+        startedAt: Date.now(),
+    });
+    // 9. Post dispatch confirmation comment
+    const worktreeDesc = worktrees
+        ? worktrees.map(wt => `\`${wt.repoName}\`: \`${wt.path}\``).join("\n")
+        : `\`${worktreePath}\``;
+    const statusComment = [
+        `**Dispatched** as **${assessment.tier}** (${assessment.model})`,
+        `> ${assessment.reasoning}`,
+        ``,
+        worktrees
+            ? `Worktrees ${worktreeResumed ? "(resumed)" : "(fresh)"}:\n${worktreeDesc}`
+            : `Worktree: ${worktreeDesc} ${worktreeResumed ? "(resumed)" : "(fresh)"}`,
+        `Branch: \`${worktreeBranch}\``,
+        ``,
+        `**Status:** Worker is starting now. An independent audit runs automatically after implementation.`,
+        ``,
+        `**While you wait:**`,
+        `- Check progress: \`/dispatch status ${identifier}\``,
+        `- Cancel: \`/dispatch escalate ${identifier} "reason"\``,
+        `- All dispatches: \`/dispatch list\``,
+    ].join("\n");
+    await createCommentWithDedup(linearApi, issue.id, statusComment);
+    if (agentSessionId) {
+        await linearApi.emitActivity(agentSessionId, {
+            type: "thought",
+            body: `Dispatching ${identifier} as ${assessment.tier}...`,
+        }).catch(() => { });
+    }
+    // 10. Apply tier label (best effort)
+    try {
+        if (enrichedIssue.team?.id) {
+            const teamLabels = await linearApi.getTeamLabels(enrichedIssue.team.id);
+            const tierLabel = teamLabels.find((l) => l.name === `developer:${assessment.tier}`);
+            if (tierLabel) {
+                const currentLabelIds = enrichedIssue.labels?.nodes?.map((l) => l.id) ?? [];
+                await linearApi.updateIssue(issue.id, {
+                    labelIds: [...currentLabelIds, tierLabel.id],
+                });
+            }
+        }
+    }
+    catch (err) {
+        api.logger.warn(`@dispatch: could not apply tier label: ${err}`);
+    }
+    // 11. Run v2 pipeline: worker → audit → verdict (non-blocking)
+    // (activeRuns already set in step 6 above)
+    // Instantiate notifier (Discord, Slack, or both — config-driven)
+    const notify = createNotifierFromConfig(pluginConfig, api.runtime, api);
+    const hookCtx = {
+        api,
+        linearApi,
+        notify,
+        pluginConfig,
+        configPath: statePath,
+    };
+    // Re-read dispatch to get fresh state after registration
+    const freshState = await readDispatchState(statePath);
+    const dispatch = getActiveDispatch(freshState, identifier);
+    await notify("dispatch", {
+        identifier,
+        title: enrichedIssue.title ?? "(untitled)",
+        status: "dispatched",
+    });
+    // spawnWorker handles: dispatched→working→auditing→done/rework/stuck
+    spawnWorker(hookCtx, dispatch)
+        .catch(async (err) => {
+        api.logger.error(`@dispatch: pipeline v2 failed for ${identifier}: ${err}`);
+        await updateDispatchStatus(identifier, "failed", statePath);
+        // Write memory for failed dispatches so they're searchable in dispatch history
+        try {
+            const wsDir = resolveOrchestratorWorkspace(api, pluginConfig);
+            writeDispatchMemory(identifier, `Pipeline failed: ${String(err).slice(0, 500)}`, wsDir, {
+                title: enrichedIssue.title ?? identifier,
+                tier: assessment.tier,
+                status: "failed",
+                project: enrichedIssue?.project?.id,
+                attempts: 1,
+                model: assessment.model,
+            });
+        }
+        catch { /* best effort */ }
+    })
+        .finally(() => {
+        activeRuns.delete(issue.id);
+        clearActiveSession(issue.id);
+    });
+}
+// ── Steering handler ──────────────────────────────────────────────
+//
+// Handle user input during an active tmux-wrapped dispatch.
+// Routes to a short orchestrator agent session that can steer, capture, or abort.
+async function handleSteeringInput(api, ctx) {
+    const { session, issue, userMessage, tmuxSession, pluginConfig } = ctx;
+    const linearApi = createLinearApi(api);
+    if (!linearApi) {
+        api.logger.error("handleSteeringInput: no Linear API");
+        return;
+    }
+    // 1. Capture recent coding agent output for context
+    let agentOutput = "";
+    try {
+        agentOutput = capturePane(tmuxSession.sessionName, 50);
+    }
+    catch (err) {
+        api.logger.warn(`handleSteeringInput: capturePane failed: ${err}`);
+    }
+    // 2. Read dispatch state for context
+    let dispatchCtx = "";
+    try {
+        const state = await readDispatchState(pluginConfig?.dispatchStatePath);
+        const dispatch = getActiveDispatch(state, tmuxSession.issueIdentifier);
+        if (dispatch) {
+            dispatchCtx = [
+                `Worktree: ${dispatch.worktreePath}`,
+                `Attempt: ${dispatch.attempt} | Status: ${dispatch.status}`,
+                `Tier: ${dispatch.tier}`,
+            ].join("\n");
+        }
+    }
+    catch { /* proceed without dispatch context */ }
+    // 3. Build steering prompt
+    const prompt = [
+        `You are a steering orchestrator. A ${tmuxSession.backend} coding agent is currently ` +
+            `working on issue ${tmuxSession.issueIdentifier}. The user just sent a message in the Linear session.`,
+        ``,
+        `## Issue Context`,
+        `**${tmuxSession.issueIdentifier}**: ${issue?.title ?? "(untitled)"}`,
+        dispatchCtx || `Backend: ${tmuxSession.backend}`,
+        `Steering mode: ${tmuxSession.steeringMode}`,
+        ``,
+        `## Recent Agent Output (last 50 lines)`,
+        "```",
+        agentOutput || "(no output captured)",
+        "```",
+        ``,
+        `## User's Message`,
+        `> ${sanitizePromptInput(userMessage, 2000)}`,
+        ``,
+        `## Your Decision`,
+        `Analyze the user's message in the context of what the coding agent is doing.`,
+        ``,
+        `**Use \`steer_agent\`** (issueId="${issue.id}") if the user is:`,
+        `- Providing information the agent needs (docs location, tool name, API details)`,
+        `- Answering a question the agent asked`,
+        `- Redirecting the agent's approach ("focus on X first", "use library Y")`,
+        `→ Craft a PRECISE, actionable message. Don't forward raw user text.`,
+        `  Translate vague input into clear instructions with file paths, code refs, etc.`,
+        tmuxSession.steeringMode === "one-shot"
+            ? `⚠️ WARNING: ${tmuxSession.backend} is in ONE-SHOT mode — steer_agent will fail. You can only abort or respond directly.`
+            : "",
+        ``,
+        `**Use \`capture_agent_output\`** (issueId="${issue.id}") if you need more context before deciding.`,
+        ``,
+        `**Use \`abort_agent\`** (issueId="${issue.id}") if the user wants to stop/cancel the run.`,
+        ``,
+        `**Respond directly (just output text)** if the user is:`,
+        `- Asking a status question ("what's it doing?", "how far along?")`,
+        `- Making a request for you, not the coding agent`,
+        ``,
+        `Be fast and decisive. This is a mid-task steering call, not a conversation.`,
+    ].filter(Boolean).join("\n");
+    // 4. Emit acknowledgment
+    const ackBody = `Processing your input while ${tmuxSession.backend} agent is working...`;
+    trackEmittedActivity(ackBody);
+    await linearApi.emitActivity(session.id, {
+        type: "thought",
+        body: ackBody,
+    }).catch(() => { });
+    // 5. Run SHORT orchestrator session (60s timeout)
+    try {
+        const { runAgent } = await import("../agent/agent.js");
+        const result = await runAgent({
+            api,
+            agentId: resolveAgentId(api),
+            sessionId: `linear-steer-${session.id}-${Date.now()}`,
+            message: prompt,
+            timeoutMs: 60_000,
+            streaming: { linearApi, agentSessionId: session.id },
+            toolsDeny: [
+                "cli_codex",
+                "cli_claude",
+                "cli_gemini",
+                "dispatch_history",
+                "plan_audit",
+                "plan_create_issue",
+                "plan_link_issues",
+                "plan_update_issue",
+                "write",
+                "edit",
+                "apply_patch",
+                "spawn_agent",
+                "ask_agent",
+            ],
+        });
+        // 6. Post response if orchestrator responded directly (not via tool)
+        if (result.success && result.output.trim()) {
+            const responseBody = result.output;
+            trackEmittedActivity(responseBody);
+            await linearApi.emitActivity(session.id, {
+                type: "response",
+                body: responseBody,
+            }).catch(() => { });
+        }
+    }
+    catch (err) {
+        api.logger.error(`handleSteeringInput error: ${err}`);
+        const errBody = `Steering failed: ${String(err).slice(0, 300)}`;
+        trackEmittedActivity(errBody);
+        await linearApi.emitActivity(session.id, {
+            type: "error",
+            body: errBody,
+        }).catch(() => { });
+    }
+}

--- a/dist/src/tools/claude-tool.js
+++ b/dist/src/tools/claude-tool.js
@@ -1,0 +1,325 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import path from "node:path";
+import { buildLinearApi, resolveSession, extractPrompt, DEFAULT_BASE_REPO, formatActivityLogLine, createProgressEmitter, } from "./cli-shared.js";
+import { InactivityWatchdog, resolveWatchdogConfig } from "../agent/watchdog.js";
+import { isTmuxAvailable, buildSessionName, shellEscape } from "../infra/tmux.js";
+import { runInTmux } from "../infra/tmux-runner.js";
+const CLAUDE_BIN = "claude";
+/**
+ * Map a Claude Code stream-json JSONL event to a Linear activity.
+ *
+ * Claude event types:
+ *   system(init) → assistant (text|tool_use) → user (tool_result) → result
+ */
+function mapClaudeEventToActivity(event) {
+    const type = event?.type;
+    // Assistant message — text response and/or tool use (emit all blocks)
+    if (type === "assistant") {
+        const content = event.message?.content;
+        if (!Array.isArray(content))
+            return [];
+        const activities = [];
+        for (const block of content) {
+            if (block.type === "text" && block.text) {
+                activities.push({ type: "thought", body: block.text.slice(0, 1000) });
+            }
+            if (block.type === "tool_use") {
+                const toolName = block.name ?? "tool";
+                const input = block.input ?? {};
+                // Summarize the input for display
+                let paramSummary;
+                if (input.command) {
+                    paramSummary = String(input.command).slice(0, 200);
+                }
+                else if (input.file_path) {
+                    paramSummary = String(input.file_path);
+                }
+                else if (input.pattern) {
+                    paramSummary = String(input.pattern);
+                }
+                else if (input.query) {
+                    paramSummary = String(input.query).slice(0, 200);
+                }
+                else {
+                    paramSummary = JSON.stringify(input).slice(0, 500);
+                }
+                activities.push({ type: "action", action: `Running ${toolName}`, parameter: paramSummary });
+            }
+        }
+        return activities;
+    }
+    // Tool result
+    if (type === "user") {
+        const content = event.message?.content;
+        if (!Array.isArray(content))
+            return [];
+        const activities = [];
+        for (const block of content) {
+            if (block.type === "tool_result") {
+                const output = typeof block.content === "string" ? block.content : "";
+                const truncated = output.length > 1000 ? output.slice(0, 1000) + "..." : output;
+                const isError = block.is_error === true;
+                activities.push({
+                    type: "action",
+                    action: isError ? "Tool error" : "Tool result",
+                    parameter: truncated || "(no output)",
+                });
+            }
+        }
+        return activities;
+    }
+    // Final result
+    if (type === "result") {
+        const cost = event.total_cost_usd;
+        const turns = event.num_turns ?? 0;
+        const usage = event.usage;
+        const parts = [`Claude completed (${turns} turns)`];
+        if (cost != null)
+            parts.push(`$${cost.toFixed(4)}`);
+        if (usage) {
+            const input = usage.input_tokens ?? 0;
+            const output = usage.output_tokens ?? 0;
+            parts.push(`${input} in / ${output} out tokens`);
+        }
+        return [{ type: "thought", body: parts.join(" — ") }];
+    }
+    return [];
+}
+/**
+ * Run Claude Code CLI with JSONL streaming, mapping events to Linear activities.
+ */
+export async function runClaude(api, params, pluginConfig, onUpdate) {
+    api.logger.info(`claude_run params: ${JSON.stringify(params).slice(0, 500)}`);
+    const prompt = extractPrompt(params);
+    if (!prompt) {
+        return {
+            success: false,
+            output: `claude_run error: no prompt provided. Received keys: ${Object.keys(params).join(", ")}`,
+            error: "missing prompt",
+        };
+    }
+    const { model, timeoutMs } = params;
+    const { agentSessionId, issueId, issueIdentifier } = resolveSession(params);
+    api.logger.info(`claude_run: session=${agentSessionId ?? "none"}, issue=${issueIdentifier ?? "none"}`);
+    const agentId = params.agentId ?? pluginConfig?.defaultAgentId ?? "default";
+    const wdConfig = resolveWatchdogConfig(agentId, pluginConfig ?? undefined);
+    const timeout = timeoutMs ?? pluginConfig?.claudeTimeoutMs ?? wdConfig.toolTimeoutMs;
+    const workingDir = params.workingDir ?? pluginConfig?.claudeBaseRepo ?? DEFAULT_BASE_REPO;
+    const linearApi = buildLinearApi(api, agentSessionId);
+    if (linearApi && agentSessionId) {
+        await linearApi.emitActivity(agentSessionId, {
+            type: "thought",
+            body: `Starting Claude Code: "${prompt.slice(0, 100)}${prompt.length > 100 ? "..." : ""}"`,
+        }).catch(() => { });
+    }
+    // Build claude command
+    const args = [
+        "--print",
+        "--output-format", "stream-json",
+        "--verbose",
+        "--dangerously-skip-permissions",
+    ];
+    if (model ?? pluginConfig?.claudeModel) {
+        args.push("--model", (model ?? pluginConfig?.claudeModel));
+    }
+    args.push("-p", prompt);
+    const fullCommand = `${CLAUDE_BIN} ${args.join(" ")}`;
+    api.logger.info(`Claude exec: ${fullCommand.slice(0, 200)}...`);
+    const progressHeader = `[claude] ${workingDir}\n$ ${fullCommand.slice(0, 500)}\n\nPrompt: ${prompt}`;
+    // --- tmux path: run inside a tmux session with pipe-pane streaming ---
+    const tmuxEnabled = pluginConfig?.enableTmux !== false;
+    if (tmuxEnabled && isTmuxAvailable()) {
+        const sessionName = buildSessionName(issueIdentifier ?? "unknown", "claude", 0);
+        const tmuxIssueId = issueId ?? sessionName;
+        const modelArgs = (model ?? pluginConfig?.claudeModel)
+            ? `--model ${shellEscape((model ?? pluginConfig?.claudeModel))}`
+            : "";
+        // Build env prefix: unset CLAUDECODE (avoids "nested session" error)
+        // and inject API key from plugin config if configured
+        const envParts = ["unset CLAUDECODE CLAUDE_CODE_ENTRYPOINT;"];
+        const claudeApiKey = pluginConfig?.claudeApiKey;
+        if (claudeApiKey) {
+            envParts.push(`export ANTHROPIC_API_KEY=${shellEscape(claudeApiKey)};`);
+        }
+        const cmdStr = [
+            ...envParts,
+            CLAUDE_BIN,
+            "--print", "--output-format", "stream-json", "--verbose", "--dangerously-skip-permissions",
+            modelArgs,
+            "-p", shellEscape(prompt),
+        ].filter(Boolean).join(" ");
+        return runInTmux({
+            issueId: tmuxIssueId,
+            issueIdentifier: issueIdentifier ?? "unknown",
+            sessionName,
+            command: cmdStr,
+            cwd: workingDir,
+            timeoutMs: timeout,
+            watchdogMs: wdConfig.inactivityMs,
+            logPath: path.join(workingDir, ".claw", `tmux-${sessionName}.jsonl`),
+            mapEvent: mapClaudeEventToActivity,
+            linearApi: linearApi ?? undefined,
+            agentSessionId: agentSessionId ?? undefined,
+            steeringMode: "stdin-pipe",
+            logger: api.logger,
+            onUpdate,
+            progressHeader,
+        });
+    }
+    // --- fallback: direct spawn ---
+    return new Promise((resolve) => {
+        // Must unset CLAUDECODE to avoid "nested session" error
+        const env = { ...process.env };
+        delete env.CLAUDECODE;
+        // Pass Anthropic API key if configured (plugin config takes precedence over env)
+        const claudeApiKey = pluginConfig?.claudeApiKey;
+        if (claudeApiKey) {
+            env.ANTHROPIC_API_KEY = claudeApiKey;
+        }
+        const child = spawn(CLAUDE_BIN, args, {
+            stdio: ["ignore", "pipe", "pipe"],
+            cwd: workingDir,
+            env,
+            timeout: 0,
+        });
+        let killed = false;
+        let killedByWatchdog = false;
+        const timer = setTimeout(() => {
+            killed = true;
+            child.kill("SIGTERM");
+            setTimeout(() => { if (!child.killed)
+                child.kill("SIGKILL"); }, 5_000);
+        }, timeout);
+        const watchdog = new InactivityWatchdog({
+            inactivityMs: wdConfig.inactivityMs,
+            label: `claude:${agentSessionId ?? "unknown"}`,
+            logger: api.logger,
+            onKill: () => {
+                killedByWatchdog = true;
+                killed = true;
+                clearTimeout(timer);
+                child.kill("SIGTERM");
+                setTimeout(() => { if (!child.killed)
+                    child.kill("SIGKILL"); }, 5_000);
+            },
+        });
+        watchdog.start();
+        const collectedMessages = [];
+        const collectedCommands = [];
+        let stderrOutput = "";
+        let lastToolName = "";
+        const progress = createProgressEmitter({ header: progressHeader, onUpdate });
+        progress.emitHeader();
+        const rl = createInterface({ input: child.stdout });
+        rl.on("line", (line) => {
+            if (!line.trim())
+                return;
+            watchdog.tick();
+            let event;
+            try {
+                event = JSON.parse(line);
+            }
+            catch {
+                collectedMessages.push(line);
+                return;
+            }
+            // Collect assistant text for final output
+            if (event.type === "assistant") {
+                const content = event.message?.content;
+                if (Array.isArray(content)) {
+                    for (const block of content) {
+                        if (block.type === "text" && block.text) {
+                            collectedMessages.push(block.text);
+                        }
+                        if (block.type === "tool_use") {
+                            lastToolName = block.name ?? "tool";
+                        }
+                    }
+                }
+            }
+            // Collect tool results for final output
+            if (event.type === "user") {
+                const content = event.message?.content;
+                const toolResult = event.tool_use_result;
+                if (Array.isArray(content)) {
+                    for (const block of content) {
+                        if (block.type === "tool_result") {
+                            const output = toolResult?.stdout ?? (typeof block.content === "string" ? block.content : "");
+                            const isError = block.is_error === true;
+                            const truncOutput = output.length > 500 ? output.slice(0, 500) + "..." : output;
+                            if (truncOutput) {
+                                collectedCommands.push(`\`${lastToolName}\` → ${isError ? "error" : "ok"}${truncOutput ? "\n```\n" + truncOutput + "\n```" : ""}`);
+                            }
+                        }
+                    }
+                }
+            }
+            // Collect final result text
+            if (event.type === "result" && event.result) {
+                // result.result contains the final answer — only add if we haven't already captured it
+                // (it duplicates the last assistant text message)
+            }
+            // Stream activities to Linear + session progress
+            const activities = mapClaudeEventToActivity(event);
+            for (const activity of activities) {
+                if (linearApi && agentSessionId) {
+                    linearApi.emitActivity(agentSessionId, activity).catch((err) => {
+                        api.logger.warn(`Failed to emit Claude activity: ${err}`);
+                    });
+                }
+                progress.push(formatActivityLogLine(activity));
+            }
+        });
+        child.stderr?.on("data", (chunk) => {
+            watchdog.tick();
+            stderrOutput += chunk.toString();
+        });
+        child.on("close", (code) => {
+            clearTimeout(timer);
+            watchdog.stop();
+            rl.close();
+            const parts = [];
+            if (collectedMessages.length > 0)
+                parts.push(collectedMessages.join("\n\n"));
+            if (collectedCommands.length > 0)
+                parts.push(collectedCommands.join("\n\n"));
+            const output = parts.join("\n\n") || stderrOutput || "(no output)";
+            if (killed) {
+                const errorType = killedByWatchdog ? "inactivity_timeout" : "timeout";
+                const reason = killedByWatchdog
+                    ? `Claude killed by inactivity watchdog (no I/O for ${Math.round(wdConfig.inactivityMs / 1000)}s)`
+                    : `Claude timed out after ${Math.round(timeout / 1000)}s`;
+                api.logger.warn(reason);
+                resolve({
+                    success: false,
+                    output: `${reason}. Partial output:\n${output}`,
+                    error: errorType,
+                });
+                return;
+            }
+            if (code !== 0) {
+                api.logger.warn(`Claude exited with code ${code}`);
+                resolve({
+                    success: false,
+                    output: `Claude failed (exit ${code}):\n${output}`,
+                    error: `exit ${code}`,
+                });
+                return;
+            }
+            api.logger.info(`Claude completed successfully`);
+            resolve({ success: true, output });
+        });
+        child.on("error", (err) => {
+            clearTimeout(timer);
+            watchdog.stop();
+            rl.close();
+            api.logger.error(`Claude spawn error: ${err}`);
+            resolve({
+                success: false,
+                output: `Failed to start Claude: ${err.message}`,
+                error: err.message,
+            });
+        });
+    });
+}

--- a/dist/src/tools/cli-shared.js
+++ b/dist/src/tools/cli-shared.js
@@ -1,0 +1,89 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { resolveLinearToken, LinearAgentApi as LinearAgentApiClass } from "../api/linear-api.js";
+import { getCurrentSession, getActiveSessionByIdentifier } from "../pipeline/active-session.js";
+export const DEFAULT_TIMEOUT_MS = 10 * 60_000; // 10 minutes (legacy — prefer watchdog config)
+export { DEFAULT_INACTIVITY_SEC, DEFAULT_MAX_TOTAL_SEC, DEFAULT_TOOL_TIMEOUT_SEC } from "../agent/watchdog.js";
+export const DEFAULT_BASE_REPO = join(homedir(), "ai-workspace");
+/**
+ * Format a Linear activity as a single streaming log line for session progress.
+ */
+export function formatActivityLogLine(activity) {
+    if (activity.type === "thought") {
+        return `▸ ${(activity.body ?? "").slice(0, 300)}`;
+    }
+    if (activity.type === "action") {
+        const result = activity.result ? `\n  → ${activity.result.slice(0, 200)}` : "";
+        return `▸ ${activity.action ?? ""}: ${(activity.parameter ?? "").slice(0, 300)}${result}`;
+    }
+    return `▸ ${JSON.stringify(activity).slice(0, 300)}`;
+}
+/**
+ * Create a progress emitter that maintains a rolling log of streaming events.
+ * Calls onUpdate with the full accumulated log on each new event.
+ */
+export function createProgressEmitter(opts) {
+    const lines = [];
+    const maxLines = opts.maxLines ?? 40;
+    const { header, onUpdate } = opts;
+    function emit() {
+        if (!onUpdate)
+            return;
+        const log = lines.length > 0 ? "\n---\n" + lines.join("\n") : "";
+        try {
+            onUpdate({ status: "running", summary: header + log });
+        }
+        catch { }
+    }
+    return {
+        emitHeader() { emit(); },
+        push(line) {
+            lines.push(line);
+            if (lines.length > maxLines)
+                lines.splice(0, lines.length - maxLines);
+            emit();
+        },
+    };
+}
+/**
+ * Build a LinearAgentApi instance for streaming activities to Linear.
+ */
+export function buildLinearApi(api, agentSessionId) {
+    if (!agentSessionId)
+        return null;
+    const pluginConfig = api.pluginConfig;
+    const tokenInfo = resolveLinearToken(pluginConfig);
+    if (!tokenInfo.accessToken)
+        return null;
+    const clientId = pluginConfig?.clientId ?? process.env.LINEAR_CLIENT_ID;
+    const clientSecret = pluginConfig?.clientSecret ?? process.env.LINEAR_CLIENT_SECRET;
+    return new LinearAgentApiClass(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+        clientId: clientId ?? undefined,
+        clientSecret: clientSecret ?? undefined,
+    });
+}
+/**
+ * Resolve session info from explicit params or the active session registry.
+ */
+export function resolveSession(params) {
+    let { issueId, issueIdentifier, agentSessionId } = params;
+    if (!agentSessionId || !issueIdentifier) {
+        const active = issueIdentifier
+            ? getActiveSessionByIdentifier(issueIdentifier)
+            : getCurrentSession();
+        if (active) {
+            agentSessionId = agentSessionId ?? active.agentSessionId;
+            issueId = issueId ?? active.issueId;
+            issueIdentifier = issueIdentifier ?? active.issueIdentifier;
+        }
+    }
+    return { agentSessionId, issueId, issueIdentifier };
+}
+/**
+ * Robustly extract a prompt from params, handling various key names.
+ */
+export function extractPrompt(params) {
+    return params.prompt ?? params.text ?? params.message ?? params.task;
+}

--- a/dist/src/tools/code-tool.js
+++ b/dist/src/tools/code-tool.js
@@ -1,0 +1,246 @@
+import { execFile } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { jsonResult } from "openclaw/plugin-sdk/core";
+import { getCurrentSession, getActiveSessionByAgentId } from "../pipeline/active-session.js";
+import { runCodex } from "./codex-tool.js";
+import { runClaude } from "./claude-tool.js";
+import { runGemini } from "./gemini-tool.js";
+import { DEFAULT_BASE_REPO } from "./cli-shared.js";
+const BACKENDS = {
+    codex: {
+        label: "Codex CLI (OpenAI)",
+        toolName: "cli_codex",
+        runner: runCodex,
+        description: "Run OpenAI Codex CLI to perform a coding task. " +
+            "Can read/write files, run commands, search code, run tests. " +
+            "Streams progress to Linear in real-time.",
+        configKeyTimeout: "codexTimeoutMs",
+        configKeyBaseRepo: "codexBaseRepo",
+    },
+    claude: {
+        label: "Claude Code (Anthropic)",
+        toolName: "cli_claude",
+        runner: runClaude,
+        description: "Run Anthropic Claude Code CLI to perform a coding task. " +
+            "Can read/write files, run commands, search code, run tests. " +
+            "Streams progress to Linear in real-time.",
+        configKeyTimeout: "claudeTimeoutMs",
+        configKeyBaseRepo: "claudeBaseRepo",
+    },
+    gemini: {
+        label: "Gemini CLI (Google)",
+        toolName: "cli_gemini",
+        runner: runGemini,
+        description: "Run Google Gemini CLI to perform a coding task. " +
+            "Can read/write files, run commands, search code, run tests. " +
+            "Streams progress to Linear in real-time.",
+        configKeyTimeout: "geminiTimeoutMs",
+        configKeyBaseRepo: "geminiBaseRepo",
+    },
+};
+/**
+ * Load coding tool config from the plugin's coding-tools.json file.
+ * Falls back to empty config if the file doesn't exist or is invalid.
+ */
+export function loadCodingConfig() {
+    try {
+        const pluginRoot = join(dirname(fileURLToPath(import.meta.url)), "../..");
+        const raw = readFileSync(join(pluginRoot, "coding-tools.json"), "utf8");
+        return JSON.parse(raw);
+    }
+    catch {
+        return {};
+    }
+}
+/**
+ * Resolve which coding backend to use for a given agent.
+ *
+ * Priority:
+ *   1. Per-agent override: config.agentCodingTools[agentId]
+ *   2. Global default: config.codingTool
+ *   3. Hardcoded fallback: "codex"
+ */
+export function resolveCodingBackend(config, agentId) {
+    if (agentId) {
+        const override = config.agentCodingTools?.[agentId];
+        if (override && override in BACKENDS)
+            return override;
+    }
+    const global = config.codingTool;
+    if (global && global in BACKENDS)
+        return global;
+    return "codex";
+}
+/**
+ * Resolve the tool name (cli_codex, cli_claude, cli_gemini) for a given agent.
+ */
+export function resolveToolName(config, agentId) {
+    return BACKENDS[resolveCodingBackend(config, agentId)].toolName;
+}
+/**
+ * Parse a session key to extract channel routing info for progress messages.
+ */
+function parseChannelTarget(sessionKey) {
+    if (!sessionKey)
+        return null;
+    const parts = sessionKey.split(":");
+    if (parts.length < 5 || parts[0] !== "agent")
+        return null;
+    const provider = parts[2];
+    const kind = parts[3];
+    if (!provider || !kind)
+        return null;
+    const peerId = parts[4];
+    if (!peerId)
+        return null;
+    return { provider, peerId };
+}
+/**
+ * Create a channel sender that can send messages to the session's channel.
+ */
+function createChannelSender(api, sessionKey) {
+    const target = parseChannelTarget(sessionKey);
+    if (!target)
+        return null;
+    const { provider, peerId } = target;
+    // 2026.4 dropped runtime.channel.<discord|telegram>.sendMessage* in favor of
+    // a capability-grouped channel runtime. Fall back to the gateway CLI for
+    // out-of-band progress messages — this path is low-frequency (one call per
+    // CLI tool run) so the subprocess cost is acceptable.
+    if (provider === "discord" || provider === "telegram") {
+        return async (text) => {
+            await new Promise((resolve) => {
+                execFile("openclaw", ["message", "send", "--channel", provider, "--target", peerId, "--message", text, "--json"], { timeout: 30_000 }, (err) => {
+                    if (err)
+                        api.logger.warn(`cli channel send (${provider}) failed: ${err.message}`);
+                    resolve();
+                });
+            });
+        };
+    }
+    return null;
+}
+/**
+ * Inject Linear session info into tool params so backend runners can emit
+ * activities to the correct Linear agent session.
+ */
+function injectSessionInfo(params, ctx) {
+    const ctxAgentId = ctx.agentId;
+    const activeSession = getCurrentSession()
+        ?? (ctxAgentId ? getActiveSessionByAgentId(ctxAgentId) : null);
+    if (activeSession) {
+        if (!params.agentSessionId)
+            params.agentSessionId = activeSession.agentSessionId;
+        if (!params.issueId)
+            params.issueId = activeSession.issueId;
+        if (!params.issueIdentifier)
+            params.issueIdentifier = activeSession.issueIdentifier;
+    }
+}
+/**
+ * Create the three coding CLI tools: cli_codex, cli_claude, cli_gemini.
+ *
+ * Each tool directly invokes its backend CLI. The tool name shown in Linear
+ * reflects which CLI is running (e.g. "Running cli_codex").
+ */
+export function createCodeTools(api, rawCtx) {
+    const ctx = rawCtx;
+    const pluginConfig = api.pluginConfig;
+    const codingConfig = loadCodingConfig();
+    const tools = [];
+    for (const [backendId, backend] of Object.entries(BACKENDS)) {
+        const tool = {
+            name: backend.toolName,
+            label: backend.label,
+            description: backend.description,
+            parameters: {
+                type: "object",
+                properties: {
+                    prompt: {
+                        type: "string",
+                        description: "What the coding agent should do. Be specific: include file paths, function names, " +
+                            "expected behavior, and test requirements.",
+                    },
+                    workingDir: {
+                        type: "string",
+                        description: "Override working directory (default: ~/ai-workspace).",
+                    },
+                    model: {
+                        type: "string",
+                        description: "Model override for the coding backend.",
+                    },
+                    timeoutMs: {
+                        type: "number",
+                        description: "Max runtime in milliseconds (default: 600000 = 10 min).",
+                    },
+                },
+                required: ["prompt"],
+            },
+            execute: async (toolCallId, params, ...rest) => {
+                const originalOnUpdate = typeof rest[1] === "function"
+                    ? rest[1]
+                    : undefined;
+                // Inject Linear session context
+                injectSessionInfo(params, ctx);
+                const workingDir = params.workingDir
+                    ?? pluginConfig?.[backend.configKeyBaseRepo]
+                    ?? DEFAULT_BASE_REPO;
+                const prompt = params.prompt ?? "";
+                api.logger.info(`${backend.toolName}: agent=${ctx.agentId ?? "unknown"} dir=${workingDir}`);
+                api.logger.info(`${backend.toolName} prompt: ${prompt.slice(0, 200)}`);
+                // Channel progress messaging
+                const channelSend = createChannelSender(api, ctx.sessionKey);
+                if (channelSend) {
+                    const initMsg = [
+                        `**${backend.toolName}** — ${backend.label}`,
+                        `\`${workingDir}\``,
+                        `> ${prompt.slice(0, 800)}${prompt.length > 800 ? "..." : ""}`,
+                    ].join("\n");
+                    channelSend(initMsg).catch(() => { });
+                }
+                // Throttled progress forwarding
+                let lastForwardMs = 0;
+                let lastChannelMs = 0;
+                const FORWARD_THROTTLE_MS = 30_000;
+                const CHANNEL_THROTTLE_MS = 20_000;
+                const wrappedOnUpdate = (update) => {
+                    const now = Date.now();
+                    if (originalOnUpdate && now - lastForwardMs >= FORWARD_THROTTLE_MS) {
+                        lastForwardMs = now;
+                        try {
+                            originalOnUpdate(update);
+                        }
+                        catch { }
+                    }
+                    if (channelSend && now - lastChannelMs >= CHANNEL_THROTTLE_MS) {
+                        lastChannelMs = now;
+                        const summary = String(update.summary ?? "");
+                        if (summary) {
+                            const logIdx = summary.indexOf("\n---\n");
+                            const logPart = logIdx >= 0 ? summary.slice(logIdx + 5) : "";
+                            if (logPart.trim()) {
+                                const tail = logPart.length > 1200 ? "..." + logPart.slice(-1200) : logPart;
+                                channelSend(`\`\`\`\n${tail}\n\`\`\``).catch(() => { });
+                            }
+                        }
+                    }
+                };
+                const result = await backend.runner(api, params, pluginConfig, wrappedOnUpdate);
+                return jsonResult({
+                    success: result.success,
+                    backend: backendId,
+                    output: result.output,
+                    ...(result.error ? { error: result.error } : {}),
+                });
+            },
+        };
+        tools.push(tool);
+    }
+    const defaultBackend = resolveCodingBackend(codingConfig, ctx.agentId);
+    api.logger.info(`cli tools registered: ${tools.map(t => t.name).join(", ")} (agent default: ${BACKENDS[defaultBackend].toolName})`);
+    return tools;
+}
+// Keep backward-compat export for tests that reference the old name
+export const createCodeTool = createCodeTools;

--- a/dist/src/tools/codex-tool.js
+++ b/dist/src/tools/codex-tool.js
@@ -1,0 +1,264 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import path from "node:path";
+import { buildLinearApi, resolveSession, extractPrompt, DEFAULT_BASE_REPO, formatActivityLogLine, createProgressEmitter, } from "./cli-shared.js";
+import { InactivityWatchdog, resolveWatchdogConfig } from "../agent/watchdog.js";
+import { isTmuxAvailable, buildSessionName, shellEscape } from "../infra/tmux.js";
+import { runInTmux } from "../infra/tmux-runner.js";
+const CODEX_BIN = "codex";
+/**
+ * Parse a JSONL line from `codex exec --json` and map it to a Linear activity.
+ */
+function mapCodexEventToActivity(event) {
+    const eventType = event?.type;
+    const item = event?.item;
+    if (item?.type === "reasoning") {
+        const text = item.text ?? "";
+        return [{ type: "thought", body: text ? text.slice(0, 500) : "Reasoning..." }];
+    }
+    if ((eventType === "item.completed" || eventType === "item.started") &&
+        (item?.type === "agent_message" || item?.type === "message")) {
+        const text = item.text ?? item.content ?? "";
+        if (text)
+            return [{ type: "thought", body: text.slice(0, 1000) }];
+        return [];
+    }
+    if (eventType === "item.started" && item?.type === "command_execution") {
+        const cmd = item.command ?? "unknown";
+        const cleaned = typeof cmd === "string"
+            ? cmd.replace(/^\/usr\/bin\/\w+ -lc ['"]?/, "").replace(/['"]?$/, "")
+            : JSON.stringify(cmd);
+        return [{ type: "action", action: "Running", parameter: cleaned.slice(0, 200) }];
+    }
+    if (eventType === "item.completed" && item?.type === "command_execution") {
+        const cmd = item.command ?? "unknown";
+        const exitCode = item.exit_code ?? "?";
+        const output = item.aggregated_output ?? item.output ?? "";
+        const cleaned = typeof cmd === "string"
+            ? cmd.replace(/^\/usr\/bin\/\w+ -lc ['"]?/, "").replace(/['"]?$/, "")
+            : JSON.stringify(cmd);
+        const truncated = output.length > 1000 ? output.slice(0, 1000) + "..." : output;
+        return [{
+                type: "action",
+                action: `${cleaned.slice(0, 150)}`,
+                parameter: `exit ${exitCode}`,
+                result: truncated || undefined,
+            }];
+    }
+    if (eventType === "item.completed" && item?.type === "file_changes") {
+        const files = item.files ?? [];
+        const fileList = Array.isArray(files) ? files.join(", ") : String(files);
+        const preview = (item.diff ?? item.content ?? "").slice(0, 500) || undefined;
+        return [{ type: "action", action: "Modified files", parameter: fileList || "unknown files", result: preview }];
+    }
+    if (eventType === "turn.completed") {
+        const usage = event.usage;
+        if (usage) {
+            const input = usage.input_tokens ?? 0;
+            const cached = usage.cached_input_tokens ?? 0;
+            const output = usage.output_tokens ?? 0;
+            return [{ type: "thought", body: `Codex turn complete (${input} in / ${cached} cached / ${output} out tokens)` }];
+        }
+        return [{ type: "thought", body: "Codex turn complete" }];
+    }
+    return [];
+}
+/**
+ * Run Codex CLI with JSONL streaming, mapping events to Linear activities in real-time.
+ */
+export async function runCodex(api, params, pluginConfig, onUpdate) {
+    api.logger.info(`codex_run params: ${JSON.stringify(params).slice(0, 500)}`);
+    const prompt = extractPrompt(params);
+    if (!prompt) {
+        return {
+            success: false,
+            output: `codex_run error: no prompt provided. Received keys: ${Object.keys(params).join(", ")}`,
+            error: "missing prompt",
+        };
+    }
+    const { model, timeoutMs } = params;
+    const { agentSessionId, issueId, issueIdentifier } = resolveSession(params);
+    api.logger.info(`codex_run: session=${agentSessionId ?? "none"}, issue=${issueIdentifier ?? "none"}`);
+    const agentId = params.agentId ?? pluginConfig?.defaultAgentId ?? "default";
+    const wdConfig = resolveWatchdogConfig(agentId, pluginConfig ?? undefined);
+    const timeout = timeoutMs ?? pluginConfig?.codexTimeoutMs ?? wdConfig.toolTimeoutMs;
+    const workingDir = params.workingDir ?? pluginConfig?.codexBaseRepo ?? DEFAULT_BASE_REPO;
+    // Build Linear API for activity streaming
+    const linearApi = buildLinearApi(api, agentSessionId);
+    if (linearApi && agentSessionId) {
+        await linearApi.emitActivity(agentSessionId, {
+            type: "thought",
+            body: `Starting Codex: "${prompt.slice(0, 100)}${prompt.length > 100 ? "..." : ""}"`,
+        }).catch(() => { });
+    }
+    // Build codex command
+    const args = ["exec", "--full-auto", "--json", "--ephemeral"];
+    if (model ?? pluginConfig?.codexModel) {
+        args.push("--model", (model ?? pluginConfig?.codexModel));
+    }
+    args.push("-C", workingDir);
+    args.push(prompt);
+    const fullCommand = `${CODEX_BIN} ${args.join(" ")}`;
+    api.logger.info(`Codex exec: ${fullCommand.slice(0, 200)}...`);
+    const progressHeader = `[codex] ${workingDir}\n$ ${fullCommand.slice(0, 500)}\n\nPrompt: ${prompt}`;
+    // --- tmux path: run inside a tmux session with pipe-pane streaming ---
+    const tmuxEnabled = pluginConfig?.enableTmux !== false;
+    if (tmuxEnabled && isTmuxAvailable()) {
+        const sessionName = buildSessionName(issueIdentifier ?? "unknown", "codex", 0);
+        const tmuxIssueId = issueId ?? sessionName;
+        const modelArgs = (model ?? pluginConfig?.codexModel)
+            ? `--model ${shellEscape((model ?? pluginConfig?.codexModel))}`
+            : "";
+        const cmdStr = [
+            CODEX_BIN, "exec", "--full-auto", "--json", "--ephemeral",
+            modelArgs,
+            "-C", shellEscape(workingDir),
+            shellEscape(prompt),
+        ].filter(Boolean).join(" ");
+        return runInTmux({
+            issueId: tmuxIssueId,
+            issueIdentifier: issueIdentifier ?? "unknown",
+            sessionName,
+            command: cmdStr,
+            cwd: workingDir,
+            timeoutMs: timeout,
+            watchdogMs: wdConfig.inactivityMs,
+            logPath: path.join(workingDir, ".claw", `tmux-${sessionName}.jsonl`),
+            mapEvent: mapCodexEventToActivity,
+            linearApi: linearApi ?? undefined,
+            agentSessionId: agentSessionId ?? undefined,
+            steeringMode: "one-shot",
+            logger: api.logger,
+            onUpdate,
+            progressHeader,
+        });
+    }
+    // --- fallback: direct spawn ---
+    return new Promise((resolve) => {
+        const child = spawn(CODEX_BIN, args, {
+            stdio: ["ignore", "pipe", "pipe"],
+            cwd: workingDir,
+            env: { ...process.env },
+            timeout: 0,
+        });
+        let killed = false;
+        let killedByWatchdog = false;
+        const timer = setTimeout(() => {
+            killed = true;
+            child.kill("SIGTERM");
+            setTimeout(() => { if (!child.killed)
+                child.kill("SIGKILL"); }, 5_000);
+        }, timeout);
+        const watchdog = new InactivityWatchdog({
+            inactivityMs: wdConfig.inactivityMs,
+            label: `codex:${agentSessionId ?? "unknown"}`,
+            logger: api.logger,
+            onKill: () => {
+                killedByWatchdog = true;
+                killed = true;
+                clearTimeout(timer);
+                child.kill("SIGTERM");
+                setTimeout(() => { if (!child.killed)
+                    child.kill("SIGKILL"); }, 5_000);
+            },
+        });
+        watchdog.start();
+        const collectedMessages = [];
+        const collectedCommands = [];
+        let stderrOutput = "";
+        const progress = createProgressEmitter({ header: progressHeader, onUpdate });
+        progress.emitHeader();
+        const rl = createInterface({ input: child.stdout });
+        rl.on("line", (line) => {
+            if (!line.trim())
+                return;
+            watchdog.tick();
+            let event;
+            try {
+                event = JSON.parse(line);
+            }
+            catch {
+                collectedMessages.push(line);
+                return;
+            }
+            const item = event?.item;
+            if (event?.type === "item.completed" &&
+                (item?.type === "agent_message" || item?.type === "message")) {
+                const text = item.text ?? item.content ?? "";
+                if (text)
+                    collectedMessages.push(text);
+            }
+            // Skip reasoning events from final output — they're streamed to
+            // Linear as activities but don't belong in the returned result.
+            if (event?.type === "item.completed" && item?.type === "command_execution") {
+                const cmd = item.command ?? "unknown";
+                const exitCode = item.exit_code ?? "?";
+                const output = item.aggregated_output ?? item.output ?? "";
+                const cleanCmd = typeof cmd === "string"
+                    ? cmd.replace(/^\/usr\/bin\/\w+ -lc ['"]?/, "").replace(/['"]?$/, "")
+                    : String(cmd);
+                const truncOutput = output.length > 500 ? output.slice(0, 500) + "..." : output;
+                collectedCommands.push(`\`${cleanCmd}\` → exit ${exitCode}${truncOutput ? "\n```\n" + truncOutput + "\n```" : ""}`);
+            }
+            const activities = mapCodexEventToActivity(event);
+            for (const activity of activities) {
+                if (linearApi && agentSessionId) {
+                    linearApi.emitActivity(agentSessionId, activity).catch((err) => {
+                        api.logger.warn(`Failed to emit Codex activity: ${err}`);
+                    });
+                }
+                progress.push(formatActivityLogLine(activity));
+            }
+        });
+        child.stderr?.on("data", (chunk) => {
+            watchdog.tick();
+            stderrOutput += chunk.toString();
+        });
+        child.on("close", (code) => {
+            clearTimeout(timer);
+            watchdog.stop();
+            rl.close();
+            const parts = [];
+            if (collectedMessages.length > 0)
+                parts.push(collectedMessages.join("\n\n"));
+            if (collectedCommands.length > 0)
+                parts.push(collectedCommands.join("\n\n"));
+            const output = parts.join("\n\n") || stderrOutput || "(no output)";
+            if (killed) {
+                const errorType = killedByWatchdog ? "inactivity_timeout" : "timeout";
+                const reason = killedByWatchdog
+                    ? `Codex killed by inactivity watchdog (no I/O for ${Math.round(wdConfig.inactivityMs / 1000)}s)`
+                    : `Codex timed out after ${Math.round(timeout / 1000)}s`;
+                api.logger.warn(reason);
+                resolve({
+                    success: false,
+                    output: `${reason}. Partial output:\n${output}`,
+                    error: errorType,
+                });
+                return;
+            }
+            if (code !== 0) {
+                api.logger.warn(`Codex exited with code ${code}`);
+                resolve({
+                    success: false,
+                    output: `Codex failed (exit ${code}):\n${output}`,
+                    error: `exit ${code}`,
+                });
+                return;
+            }
+            api.logger.info(`Codex completed successfully`);
+            resolve({ success: true, output });
+        });
+        child.on("error", (err) => {
+            clearTimeout(timer);
+            watchdog.stop();
+            rl.close();
+            api.logger.error(`Codex spawn error: ${err}`);
+            resolve({
+                success: false,
+                output: `Failed to start Codex: ${err.message}`,
+                error: err.message,
+            });
+        });
+    });
+}

--- a/dist/src/tools/dispatch-history-tool.js
+++ b/dist/src/tools/dispatch-history-tool.js
@@ -1,0 +1,174 @@
+/**
+ * dispatch-history-tool.ts — Agent tool for searching dispatch history.
+ *
+ * Searches dispatch state + memory files to provide context about
+ * past dispatches. Useful for agents to understand what work has
+ * been done on related issues.
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { jsonResult } from "openclaw/plugin-sdk/core";
+import { readDispatchState, listActiveDispatches } from "../pipeline/dispatch-state.js";
+import { resolveOrchestratorWorkspace } from "../pipeline/artifacts.js";
+export function createDispatchHistoryTool(api, pluginConfig) {
+    const statePath = pluginConfig?.dispatchStatePath;
+    return {
+        name: "dispatch_history",
+        label: "Dispatch History",
+        description: "Search dispatch history for past and active Linear issue dispatches. " +
+            "Returns issue identifier, tier, status, attempts, and summary excerpts.",
+        parameters: {
+            type: "object",
+            properties: {
+                query: {
+                    type: "string",
+                    description: "Issue identifier (e.g. 'CT-123') or keyword to search in summaries.",
+                },
+                tier: {
+                    type: "string",
+                    enum: ["small", "medium", "high"],
+                    description: "Filter by tier.",
+                },
+                status: {
+                    type: "string",
+                    enum: ["dispatched", "working", "auditing", "done", "failed", "stuck"],
+                    description: "Filter by status.",
+                },
+                limit: {
+                    type: "number",
+                    description: "Max results to return (default: 10).",
+                },
+            },
+        },
+        execute: async (_toolCallId, params) => {
+            const maxResults = params.limit ?? 10;
+            const results = [];
+            // Search active dispatches
+            const state = await readDispatchState(statePath);
+            const active = listActiveDispatches(state);
+            for (const d of active) {
+                if (matchesFilters(d.issueIdentifier, d.tier, d.status, params)) {
+                    results.push({
+                        identifier: d.issueIdentifier,
+                        tier: d.tier,
+                        status: d.status,
+                        attempts: d.attempt,
+                        active: true,
+                        taskFlowId: d.taskFlowId,
+                    });
+                }
+            }
+            // Search completed dispatches
+            for (const [id, d] of Object.entries(state.dispatches.completed)) {
+                if (matchesFilters(id, d.tier, d.status, params)) {
+                    results.push({
+                        identifier: id,
+                        tier: d.tier,
+                        status: d.status,
+                        attempts: d.totalAttempts ?? 0,
+                        active: false,
+                    });
+                }
+            }
+            // Search memory files for richer context
+            try {
+                const wsDir = resolveOrchestratorWorkspace(api, pluginConfig);
+                const memDir = join(wsDir, "memory");
+                const files = readdirSync(memDir).filter(f => f.startsWith("dispatch-") && f.endsWith(".md"));
+                for (const file of files) {
+                    const id = file.replace("dispatch-", "").replace(".md", "");
+                    // Skip if already in results
+                    if (results.some(r => r.identifier === id)) {
+                        // Enrich with summary
+                        const existing = results.find(r => r.identifier === id);
+                        if (existing && !existing.summary) {
+                            try {
+                                const content = readFileSync(join(memDir, file), "utf-8");
+                                existing.summary = extractSummaryExcerpt(content, params.query);
+                            }
+                            catch { }
+                        }
+                        continue;
+                    }
+                    // Check if memory file matches query
+                    if (params.query) {
+                        try {
+                            const content = readFileSync(join(memDir, file), "utf-8");
+                            if (id.toLowerCase().includes(params.query.toLowerCase()) ||
+                                content.toLowerCase().includes(params.query.toLowerCase())) {
+                                const meta = parseFrontmatter(content);
+                                if (matchesFilters(id, meta.tier, meta.status, params)) {
+                                    results.push({
+                                        identifier: id,
+                                        tier: meta.tier ?? "unknown",
+                                        status: meta.status ?? "completed",
+                                        attempts: meta.attempts ?? 0,
+                                        summary: extractSummaryExcerpt(content, params.query),
+                                        active: false,
+                                    });
+                                }
+                            }
+                        }
+                        catch { }
+                    }
+                }
+            }
+            catch { }
+            const limited = results.slice(0, maxResults);
+            if (limited.length === 0) {
+                return jsonResult({ message: "No dispatch history found matching the criteria.", results: [] });
+            }
+            const formatted = limited.map(r => {
+                const parts = [`**${r.identifier}** — ${r.status} (${r.tier}, ${r.attempts} attempts)${r.active ? " [ACTIVE]" : ""}`];
+                if (r.summary)
+                    parts.push(`  ${r.summary}`);
+                return parts.join("\n");
+            }).join("\n\n");
+            return jsonResult({
+                message: `Found ${limited.length} dispatch(es):\n\n${formatted}`,
+                results: limited,
+            });
+        },
+    };
+}
+function matchesFilters(identifier, tier, status, params) {
+    if (params.tier && tier !== params.tier)
+        return false;
+    if (params.status && status !== params.status)
+        return false;
+    if (params.query && !identifier.toLowerCase().includes(params.query.toLowerCase()))
+        return false;
+    return true;
+}
+function parseFrontmatter(content) {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match)
+        return {};
+    const result = {};
+    for (const line of match[1].split("\n")) {
+        const [key, ...rest] = line.split(": ");
+        if (key && rest.length > 0) {
+            let value = rest.join(": ").trim();
+            if (value.startsWith('"') && value.endsWith('"'))
+                value = value.slice(1, -1);
+            else if (!isNaN(Number(value)))
+                value = Number(value);
+            result[key.trim()] = value;
+        }
+    }
+    return result;
+}
+function extractSummaryExcerpt(content, query) {
+    // Remove frontmatter
+    const body = content.replace(/^---[\s\S]*?---\n?/, "").trim();
+    if (!query)
+        return body.slice(0, 200);
+    // Find the query in the body and return surrounding context
+    const lower = body.toLowerCase();
+    const idx = lower.indexOf(query.toLowerCase());
+    if (idx === -1)
+        return body.slice(0, 200);
+    const start = Math.max(0, idx - 50);
+    const end = Math.min(body.length, idx + query.length + 150);
+    return (start > 0 ? "..." : "") + body.slice(start, end) + (end < body.length ? "..." : "");
+}

--- a/dist/src/tools/gemini-tool.js
+++ b/dist/src/tools/gemini-tool.js
@@ -1,0 +1,273 @@
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline";
+import path from "node:path";
+import { buildLinearApi, resolveSession, extractPrompt, DEFAULT_BASE_REPO, formatActivityLogLine, createProgressEmitter, } from "./cli-shared.js";
+import { InactivityWatchdog, resolveWatchdogConfig } from "../agent/watchdog.js";
+import { isTmuxAvailable, buildSessionName, shellEscape } from "../infra/tmux.js";
+import { runInTmux } from "../infra/tmux-runner.js";
+const GEMINI_BIN = "gemini";
+/**
+ * Map a Gemini CLI stream-json JSONL event to a Linear activity.
+ *
+ * Gemini event types:
+ *   init → message(user) → message(assistant) → tool_use → tool_result → result
+ */
+function mapGeminiEventToActivity(event) {
+    const type = event?.type;
+    // Assistant message (delta text)
+    if (type === "message" && event.role === "assistant") {
+        const text = event.content;
+        if (text)
+            return [{ type: "thought", body: text.slice(0, 1000) }];
+        return [];
+    }
+    // Tool use — running a command or tool
+    if (type === "tool_use") {
+        const toolName = event.tool_name ?? "tool";
+        const params = event.parameters ?? {};
+        let paramSummary;
+        if (params.command) {
+            paramSummary = String(params.command).slice(0, 200);
+        }
+        else if (params.file_path) {
+            paramSummary = String(params.file_path);
+        }
+        else if (params.description) {
+            paramSummary = String(params.description).slice(0, 200);
+        }
+        else {
+            paramSummary = JSON.stringify(params).slice(0, 500);
+        }
+        return [{ type: "action", action: `Running ${toolName}`, parameter: paramSummary }];
+    }
+    // Tool result
+    if (type === "tool_result") {
+        const status = event.status ?? "unknown";
+        const output = event.output ?? "";
+        const truncated = output.length > 1000 ? output.slice(0, 1000) + "..." : output;
+        return [{
+                type: "action",
+                action: `Tool ${status}`,
+                parameter: truncated || "(no output)",
+            }];
+    }
+    // Final result
+    if (type === "result") {
+        const stats = event.stats;
+        const parts = ["Gemini completed"];
+        if (stats) {
+            if (stats.duration_ms)
+                parts.push(`${Math.round(stats.duration_ms / 1000)}s`);
+            if (stats.total_tokens)
+                parts.push(`${stats.total_tokens} tokens`);
+            if (stats.tool_calls)
+                parts.push(`${stats.tool_calls} tool calls`);
+        }
+        return [{ type: "thought", body: parts.join(" — ") }];
+    }
+    return [];
+}
+/**
+ * Run Gemini CLI with JSONL streaming, mapping events to Linear activities.
+ */
+export async function runGemini(api, params, pluginConfig, onUpdate) {
+    api.logger.info(`gemini_run params: ${JSON.stringify(params).slice(0, 500)}`);
+    const prompt = extractPrompt(params);
+    if (!prompt) {
+        return {
+            success: false,
+            output: `gemini_run error: no prompt provided. Received keys: ${Object.keys(params).join(", ")}`,
+            error: "missing prompt",
+        };
+    }
+    const { model, timeoutMs } = params;
+    const { agentSessionId, issueId, issueIdentifier } = resolveSession(params);
+    api.logger.info(`gemini_run: session=${agentSessionId ?? "none"}, issue=${issueIdentifier ?? "none"}`);
+    const agentId = params.agentId ?? pluginConfig?.defaultAgentId ?? "default";
+    const wdConfig = resolveWatchdogConfig(agentId, pluginConfig ?? undefined);
+    const timeout = timeoutMs ?? pluginConfig?.geminiTimeoutMs ?? wdConfig.toolTimeoutMs;
+    const workingDir = params.workingDir ?? pluginConfig?.geminiBaseRepo ?? DEFAULT_BASE_REPO;
+    const linearApi = buildLinearApi(api, agentSessionId);
+    if (linearApi && agentSessionId) {
+        await linearApi.emitActivity(agentSessionId, {
+            type: "thought",
+            body: `Starting Gemini: "${prompt.slice(0, 100)}${prompt.length > 100 ? "..." : ""}"`,
+        }).catch(() => { });
+    }
+    // Build gemini command — no -C flag, use cwd in spawn options
+    const args = [
+        "-p", prompt,
+        "-o", "stream-json",
+        "--yolo",
+    ];
+    if (model ?? pluginConfig?.geminiModel) {
+        args.push("-m", (model ?? pluginConfig?.geminiModel));
+    }
+    const fullCommand = `${GEMINI_BIN} ${args.join(" ")}`;
+    api.logger.info(`Gemini exec: ${fullCommand.slice(0, 200)}...`);
+    const progressHeader = `[gemini] ${workingDir}\n$ ${fullCommand.slice(0, 500)}\n\nPrompt: ${prompt}`;
+    // --- tmux path: run inside a tmux session with pipe-pane streaming ---
+    const tmuxEnabled = pluginConfig?.enableTmux !== false;
+    if (tmuxEnabled && isTmuxAvailable()) {
+        const sessionName = buildSessionName(issueIdentifier ?? "unknown", "gemini", 0);
+        const tmuxIssueId = issueId ?? sessionName;
+        const modelArgs = (model ?? pluginConfig?.geminiModel)
+            ? `-m ${shellEscape((model ?? pluginConfig?.geminiModel))}`
+            : "";
+        const cmdStr = [
+            GEMINI_BIN,
+            "-p", shellEscape(prompt),
+            "-o", "stream-json",
+            "--yolo",
+            modelArgs,
+        ].filter(Boolean).join(" ");
+        return runInTmux({
+            issueId: tmuxIssueId,
+            issueIdentifier: issueIdentifier ?? "unknown",
+            sessionName,
+            command: cmdStr,
+            cwd: workingDir,
+            timeoutMs: timeout,
+            watchdogMs: wdConfig.inactivityMs,
+            logPath: path.join(workingDir, ".claw", `tmux-${sessionName}.jsonl`),
+            mapEvent: mapGeminiEventToActivity,
+            linearApi: linearApi ?? undefined,
+            agentSessionId: agentSessionId ?? undefined,
+            steeringMode: "stdin-pipe",
+            logger: api.logger,
+            onUpdate,
+            progressHeader,
+        });
+    }
+    // --- fallback: direct spawn ---
+    return new Promise((resolve) => {
+        const child = spawn(GEMINI_BIN, args, {
+            stdio: ["ignore", "pipe", "pipe"],
+            cwd: workingDir,
+            env: { ...process.env },
+            timeout: 0,
+        });
+        let killed = false;
+        let killedByWatchdog = false;
+        const timer = setTimeout(() => {
+            killed = true;
+            child.kill("SIGTERM");
+            setTimeout(() => { if (!child.killed)
+                child.kill("SIGKILL"); }, 5_000);
+        }, timeout);
+        const watchdog = new InactivityWatchdog({
+            inactivityMs: wdConfig.inactivityMs,
+            label: `gemini:${agentSessionId ?? "unknown"}`,
+            logger: api.logger,
+            onKill: () => {
+                killedByWatchdog = true;
+                killed = true;
+                clearTimeout(timer);
+                child.kill("SIGTERM");
+                setTimeout(() => { if (!child.killed)
+                    child.kill("SIGKILL"); }, 5_000);
+            },
+        });
+        watchdog.start();
+        const collectedMessages = [];
+        const collectedCommands = [];
+        let stderrOutput = "";
+        const progress = createProgressEmitter({ header: progressHeader, onUpdate });
+        progress.emitHeader();
+        const rl = createInterface({ input: child.stdout });
+        rl.on("line", (line) => {
+            if (!line.trim())
+                return;
+            watchdog.tick();
+            let event;
+            try {
+                event = JSON.parse(line);
+            }
+            catch {
+                // Non-JSON lines (e.g. "YOLO mode" warnings) — skip
+                return;
+            }
+            // Collect assistant text for final output
+            if (event.type === "message" && event.role === "assistant") {
+                const text = event.content;
+                if (text)
+                    collectedMessages.push(text);
+            }
+            // Collect tool use/result for final output
+            if (event.type === "tool_use") {
+                const toolName = event.tool_name ?? "tool";
+                const cmd = event.parameters?.command ?? event.parameters?.description ?? "";
+                if (cmd)
+                    collectedCommands.push(`\`${toolName}\`: ${String(cmd).slice(0, 200)}`);
+            }
+            if (event.type === "tool_result") {
+                const output = event.output ?? "";
+                const status = event.status ?? "unknown";
+                const truncOutput = output.length > 500 ? output.slice(0, 500) + "..." : output;
+                if (truncOutput) {
+                    collectedCommands.push(`→ ${status}${truncOutput ? "\n```\n" + truncOutput + "\n```" : ""}`);
+                }
+            }
+            // Stream activities to Linear + session progress
+            const activities = mapGeminiEventToActivity(event);
+            for (const activity of activities) {
+                if (linearApi && agentSessionId) {
+                    linearApi.emitActivity(agentSessionId, activity).catch((err) => {
+                        api.logger.warn(`Failed to emit Gemini activity: ${err}`);
+                    });
+                }
+                progress.push(formatActivityLogLine(activity));
+            }
+        });
+        child.stderr?.on("data", (chunk) => {
+            watchdog.tick();
+            stderrOutput += chunk.toString();
+        });
+        child.on("close", (code) => {
+            clearTimeout(timer);
+            watchdog.stop();
+            rl.close();
+            const parts = [];
+            if (collectedMessages.length > 0)
+                parts.push(collectedMessages.join("\n\n"));
+            if (collectedCommands.length > 0)
+                parts.push(collectedCommands.join("\n\n"));
+            const output = parts.join("\n\n") || stderrOutput || "(no output)";
+            if (killed) {
+                const errorType = killedByWatchdog ? "inactivity_timeout" : "timeout";
+                const reason = killedByWatchdog
+                    ? `Gemini killed by inactivity watchdog (no I/O for ${Math.round(wdConfig.inactivityMs / 1000)}s)`
+                    : `Gemini timed out after ${Math.round(timeout / 1000)}s`;
+                api.logger.warn(reason);
+                resolve({
+                    success: false,
+                    output: `${reason}. Partial output:\n${output}`,
+                    error: errorType,
+                });
+                return;
+            }
+            if (code !== 0) {
+                api.logger.warn(`Gemini exited with code ${code}`);
+                resolve({
+                    success: false,
+                    output: `Gemini failed (exit ${code}):\n${output}`,
+                    error: `exit ${code}`,
+                });
+                return;
+            }
+            api.logger.info(`Gemini completed successfully`);
+            resolve({ success: true, output });
+        });
+        child.on("error", (err) => {
+            clearTimeout(timer);
+            watchdog.stop();
+            rl.close();
+            api.logger.error(`Gemini spawn error: ${err}`);
+            resolve({
+                success: false,
+                output: `Failed to start Gemini: ${err.message}`,
+                error: err.message,
+            });
+        });
+    });
+}

--- a/dist/src/tools/linear-issues-tool.js
+++ b/dist/src/tools/linear-issues-tool.js
@@ -1,0 +1,325 @@
+import { jsonResult } from "openclaw/plugin-sdk/core";
+import { LinearAgentApi, resolveLinearToken } from "../api/linear-api.js";
+import { isValidIssueId as isValidLinearId } from "../infra/validation.js";
+function buildApi(pluginConfig) {
+    const tokenInfo = resolveLinearToken(pluginConfig);
+    if (!tokenInfo.accessToken) {
+        throw new Error("No Linear access token configured. Run: openclaw openclaw-linear auth");
+    }
+    return new LinearAgentApi(tokenInfo.accessToken, {
+        refreshToken: tokenInfo.refreshToken,
+        expiresAt: tokenInfo.expiresAt,
+    });
+}
+// ---------------------------------------------------------------------------
+// Action handlers
+// ---------------------------------------------------------------------------
+async function handleRead(api, params) {
+    if (!params.issueId) {
+        return jsonResult({ error: "issueId is required for action='read'" });
+    }
+    if (!isValidLinearId(params.issueId)) {
+        return jsonResult({ error: `Invalid issueId format: "${params.issueId}". Expected TEAM-123 or UUID.` });
+    }
+    const issue = await api.getIssueDetails(params.issueId);
+    return jsonResult({
+        identifier: issue.identifier,
+        title: issue.title,
+        description: issue.description,
+        status: issue.state.name,
+        statusType: issue.state.type,
+        assignee: issue.assignee?.name ?? null,
+        creator: issue.creator?.name ?? null,
+        estimate: issue.estimate,
+        team: { id: issue.team.id, name: issue.team.name },
+        labels: issue.labels.nodes.map((l) => l.name),
+        project: issue.project ? { id: issue.project.id, name: issue.project.name } : null,
+        parent: issue.parent ? { id: issue.parent.id, identifier: issue.parent.identifier } : null,
+        relations: issue.relations.nodes.map((r) => ({
+            type: r.type,
+            identifier: r.relatedIssue.identifier,
+            title: r.relatedIssue.title,
+        })),
+        recentComments: issue.comments.nodes.map((c) => ({
+            author: c.user?.name ?? "Unknown",
+            body: c.body.slice(0, 500),
+            createdAt: c.createdAt,
+        })),
+    });
+}
+async function handleCreate(api, params) {
+    if (!params.title) {
+        return jsonResult({ error: "title is required for action='create'" });
+    }
+    if (params.teamId && !isValidLinearId(params.teamId)) {
+        return jsonResult({ error: `Invalid teamId format: "${params.teamId}". Expected TEAM-123 or UUID.` });
+    }
+    if (params.parentIssueId && !isValidLinearId(params.parentIssueId)) {
+        return jsonResult({ error: `Invalid parentIssueId format: "${params.parentIssueId}". Expected TEAM-123 or UUID.` });
+    }
+    if (params.projectId && !isValidLinearId(params.projectId)) {
+        return jsonResult({ error: `Invalid projectId format: "${params.projectId}". Expected TEAM-123 or UUID.` });
+    }
+    // Resolve teamId: explicit param, or derive from parent issue
+    let teamId = params.teamId;
+    let projectId = params.projectId;
+    let resolvedParentId;
+    if (params.parentIssueId) {
+        // Fetch parent to get teamId, projectId, and resolved UUID
+        const parent = await api.getIssueDetails(params.parentIssueId);
+        teamId = teamId ?? parent.team.id;
+        projectId = projectId ?? parent.project?.id ?? undefined;
+        resolvedParentId = parent.id;
+    }
+    if (!teamId) {
+        return jsonResult({
+            error: "teamId is required for action='create'. Provide it directly, or provide parentIssueId to inherit from parent.",
+        });
+    }
+    const input = {
+        teamId,
+        title: params.title,
+    };
+    if (params.description)
+        input.description = params.description;
+    if (resolvedParentId)
+        input.parentId = resolvedParentId;
+    if (projectId)
+        input.projectId = projectId;
+    if (params.priority != null)
+        input.priority = params.priority;
+    if (params.estimate != null)
+        input.estimate = params.estimate;
+    // Resolve label names → labelIds
+    if (params.labels) {
+        const teamLabels = await api.getTeamLabels(teamId);
+        const resolvedIds = [];
+        const unmatched = [];
+        for (const name of params.labels) {
+            const match = teamLabels.find((l) => l.name.toLowerCase() === name.toLowerCase());
+            if (match) {
+                resolvedIds.push(match.id);
+            }
+            else {
+                unmatched.push(name);
+            }
+        }
+        if (unmatched.length > 0) {
+            const available = teamLabels.map((l) => l.name).join(", ");
+            return jsonResult({
+                error: `Labels not found: ${unmatched.join(", ")}. Available: ${available}`,
+            });
+        }
+        input.labelIds = resolvedIds;
+    }
+    const result = await api.createIssue(input);
+    return jsonResult({
+        success: true,
+        id: result.id,
+        identifier: result.identifier,
+        parentIssueId: params.parentIssueId ?? null,
+    });
+}
+async function handleUpdate(api, params) {
+    if (!params.issueId) {
+        return jsonResult({ error: "issueId is required for action='update'" });
+    }
+    if (!isValidLinearId(params.issueId)) {
+        return jsonResult({ error: `Invalid issueId format: "${params.issueId}". Expected TEAM-123 or UUID.` });
+    }
+    const hasFields = params.status || params.priority != null || params.estimate != null || params.labels || params.title;
+    if (!hasFields) {
+        return jsonResult({ error: "At least one field (status, priority, estimate, labels, title) is required for action='update'" });
+    }
+    // Fetch issue to get teamId for name-to-ID resolution
+    const issue = await api.getIssueDetails(params.issueId);
+    const teamId = issue.team.id;
+    const updateInput = {};
+    const changes = [];
+    // Resolve status name → stateId
+    if (params.status) {
+        const states = await api.getTeamStates(teamId);
+        const match = states.find((s) => s.name.toLowerCase() === params.status.toLowerCase());
+        if (!match) {
+            const available = states.map((s) => `${s.name} (${s.type})`).join(", ");
+            return jsonResult({
+                error: `Status "${params.status}" not found. Available states: ${available}`,
+            });
+        }
+        updateInput.stateId = match.id;
+        changes.push(`status → ${match.name}`);
+    }
+    // Resolve label names → labelIds
+    if (params.labels) {
+        const teamLabels = await api.getTeamLabels(teamId);
+        const resolvedIds = [];
+        const unmatched = [];
+        for (const name of params.labels) {
+            const match = teamLabels.find((l) => l.name.toLowerCase() === name.toLowerCase());
+            if (match) {
+                resolvedIds.push(match.id);
+            }
+            else {
+                unmatched.push(name);
+            }
+        }
+        if (unmatched.length > 0) {
+            const available = teamLabels.map((l) => l.name).join(", ");
+            return jsonResult({
+                error: `Labels not found: ${unmatched.join(", ")}. Available: ${available}`,
+            });
+        }
+        updateInput.labelIds = resolvedIds;
+        changes.push(`labels → [${params.labels.join(", ")}]`);
+    }
+    if (params.priority != null) {
+        updateInput.priority = params.priority;
+        changes.push(`priority → ${params.priority}`);
+    }
+    if (params.estimate != null) {
+        updateInput.estimate = params.estimate;
+        changes.push(`estimate → ${params.estimate}`);
+    }
+    if (params.title) {
+        updateInput.title = params.title;
+        changes.push(`title → "${params.title}"`);
+    }
+    const success = await api.updateIssueExtended(params.issueId, updateInput);
+    return jsonResult({
+        success,
+        issueId: issue.identifier,
+        changes,
+    });
+}
+async function handleComment(api, params) {
+    if (!params.issueId) {
+        return jsonResult({ error: "issueId is required for action='comment'" });
+    }
+    if (!isValidLinearId(params.issueId)) {
+        return jsonResult({ error: `Invalid issueId format: "${params.issueId}". Expected TEAM-123 or UUID.` });
+    }
+    if (!params.body) {
+        return jsonResult({ error: "body is required for action='comment'" });
+    }
+    const commentId = await api.createComment(params.issueId, params.body);
+    return jsonResult({ success: true, commentId });
+}
+async function handleListStates(api, params) {
+    if (!params.teamId) {
+        return jsonResult({ error: "teamId is required for action='list_states'" });
+    }
+    if (!isValidLinearId(params.teamId)) {
+        return jsonResult({ error: `Invalid teamId format: "${params.teamId}". Expected TEAM-123 or UUID.` });
+    }
+    const states = await api.getTeamStates(params.teamId);
+    return jsonResult({ states });
+}
+async function handleListLabels(api, params) {
+    if (!params.teamId) {
+        return jsonResult({ error: "teamId is required for action='list_labels'" });
+    }
+    if (!isValidLinearId(params.teamId)) {
+        return jsonResult({ error: `Invalid teamId format: "${params.teamId}". Expected TEAM-123 or UUID.` });
+    }
+    const labels = await api.getTeamLabels(params.teamId);
+    return jsonResult({ labels });
+}
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+export function createLinearIssuesTool(api) {
+    const pluginConfig = api.pluginConfig;
+    return {
+        name: "linear_issues",
+        label: "Linear Issues",
+        description: "Read, create, update, and manage Linear issues directly via API. " +
+            "Actions: read (get issue details), create (create issue or sub-issue), " +
+            "update (change status/priority/labels/estimate/title), " +
+            "comment (post a comment), list_states (get workflow states for a team), " +
+            "list_labels (get labels for a team). " +
+            "Use action='create' with parentIssueId to create sub-issues for granular work breakdown. " +
+            "Status and label names are resolved to IDs automatically.",
+        parameters: {
+            type: "object",
+            properties: {
+                action: {
+                    type: "string",
+                    enum: ["read", "create", "update", "comment", "list_states", "list_labels"],
+                    description: "The action to perform.",
+                },
+                issueId: {
+                    type: "string",
+                    description: "Issue identifier (e.g. 'ENG-123') or UUID. Required for read, update, comment.",
+                },
+                parentIssueId: {
+                    type: "string",
+                    description: "Parent issue identifier or UUID. Used with action=create to make a sub-issue. The new issue inherits teamId and projectId from the parent.",
+                },
+                description: {
+                    type: "string",
+                    description: "Issue description with acceptance criteria. Used with action=create.",
+                },
+                projectId: {
+                    type: "string",
+                    description: "Project UUID. Used with action=create to add the issue to a project.",
+                },
+                status: {
+                    type: "string",
+                    description: "New status name (e.g. 'In Progress', 'Done', 'Backlog'). Used with action=update.",
+                },
+                priority: {
+                    type: "number",
+                    description: "Priority level 0-4 (0=none, 1=urgent, 2=high, 3=medium, 4=low). Used with action=create and action=update.",
+                },
+                estimate: {
+                    type: "number",
+                    description: "Story point estimate. Used with action=create and action=update.",
+                },
+                labels: {
+                    type: "array",
+                    items: { type: "string" },
+                    description: "Label names to set on the issue. Used with action=create and action=update.",
+                },
+                title: {
+                    type: "string",
+                    description: "Issue title. Required for action=create. Used with action=update to rename.",
+                },
+                body: {
+                    type: "string",
+                    description: "Comment body text. Required for action=comment.",
+                },
+                teamId: {
+                    type: "string",
+                    description: "Team ID. Required for list_states, list_labels, and action=create (unless parentIssueId is provided). Get it from a read action first.",
+                },
+            },
+            required: ["action"],
+        },
+        execute: async (_toolCallId, params) => {
+            try {
+                const linearApi = buildApi(pluginConfig);
+                switch (params.action) {
+                    case "read":
+                        return await handleRead(linearApi, params);
+                    case "create":
+                        return await handleCreate(linearApi, params);
+                    case "update":
+                        return await handleUpdate(linearApi, params);
+                    case "comment":
+                        return await handleComment(linearApi, params);
+                    case "list_states":
+                        return await handleListStates(linearApi, params);
+                    case "list_labels":
+                        return await handleListLabels(linearApi, params);
+                    default:
+                        return jsonResult({ error: `Unknown action: ${params.action}. Valid: read, create, update, comment, list_states, list_labels` });
+                }
+            }
+            catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                api.logger.error(`linear_issues tool error: ${message}`);
+                return jsonResult({ error: message });
+            }
+        },
+    };
+}

--- a/dist/src/tools/orchestration-tools.js
+++ b/dist/src/tools/orchestration-tools.js
@@ -1,0 +1,108 @@
+import { jsonResult } from "openclaw/plugin-sdk/core";
+import { runAgent } from "../agent/agent.js";
+/**
+ * Create orchestration tools that let agents delegate work to other crew agents.
+ *
+ * - spawn_agent: Fire-and-forget parallel delegation (non-blocking)
+ * - ask_agent: Synchronous question-answer with another agent
+ */
+export function createOrchestrationTools(api, _ctx) {
+    return [
+        {
+            name: "spawn_agent",
+            label: "Spawn Agent",
+            description: "Delegate a task to another crew agent. Runs in the background — does not block. " +
+                "Use this when you want to parallelize work (e.g., ask kaylee to investigate DB performance " +
+                "while you continue working on something else).",
+            parameters: {
+                type: "object",
+                properties: {
+                    agentId: {
+                        type: "string",
+                        description: "Which agent to dispatch (e.g., 'kaylee', 'inara', 'mal'). Must match an agent ID in openclaw.json.",
+                    },
+                    task: {
+                        type: "string",
+                        description: "Description of what the sub-agent should do.",
+                    },
+                    timeoutSeconds: {
+                        type: "number",
+                        description: "Max runtime in seconds (default: 300).",
+                    },
+                },
+                required: ["agentId", "task"],
+            },
+            execute: async (_toolCallId, { agentId, task, timeoutSeconds }) => {
+                const timeout = (timeoutSeconds ?? 300) * 1000;
+                const sessionId = `spawn-${agentId}-${Date.now()}`;
+                api.logger.info(`spawn_agent: dispatching ${agentId} — "${task.slice(0, 80)}..."`);
+                // Fire and forget — don't await the full result
+                const resultPromise = runAgent({
+                    api,
+                    agentId,
+                    sessionId,
+                    message: task,
+                    timeoutMs: timeout,
+                });
+                // Store the promise so it can be retrieved later if needed
+                resultPromise.catch((err) => {
+                    api.logger.error(`spawn_agent ${agentId} failed: ${err}`);
+                });
+                return jsonResult({
+                    message: `Dispatched task to agent '${agentId}'. It is running in the background.`,
+                    agentId,
+                    sessionId,
+                });
+            },
+        },
+        {
+            name: "ask_agent",
+            label: "Ask Agent",
+            description: "Ask another crew agent a question and wait for their reply. " +
+                "Use this when you need a specific answer before proceeding " +
+                "(e.g., 'wash, would this schema change break existing tests?').",
+            parameters: {
+                type: "object",
+                properties: {
+                    agentId: {
+                        type: "string",
+                        description: "Which agent to ask (e.g., 'kaylee', 'inara', 'mal'). Must match an agent ID in openclaw.json.",
+                    },
+                    message: {
+                        type: "string",
+                        description: "The question or request for the other agent.",
+                    },
+                    timeoutSeconds: {
+                        type: "number",
+                        description: "How long to wait for a reply in seconds (default: 120).",
+                    },
+                },
+                required: ["agentId", "message"],
+            },
+            execute: async (_toolCallId, { agentId, message, timeoutSeconds }) => {
+                const timeout = (timeoutSeconds ?? 120) * 1000;
+                const sessionId = `ask-${agentId}-${Date.now()}`;
+                api.logger.info(`ask_agent: asking ${agentId} — "${message.slice(0, 80)}..."`);
+                const result = await runAgent({
+                    api,
+                    agentId,
+                    sessionId,
+                    message,
+                    timeoutMs: timeout,
+                });
+                if (!result.success) {
+                    return jsonResult({
+                        message: `Agent '${agentId}' failed to respond.`,
+                        error: result.output.slice(0, 1000),
+                        agentId,
+                    });
+                }
+                return jsonResult({
+                    message: `Response from agent '${agentId}':`,
+                    agentId,
+                    response: result.output,
+                });
+            },
+        },
+    ];
+}

--- a/dist/src/tools/planner-tools.js
+++ b/dist/src/tools/planner-tools.js
@@ -1,0 +1,376 @@
+import { jsonResult } from "openclaw/plugin-sdk/core";
+// ---------------------------------------------------------------------------
+// Context injection (set before runAgent, cleared after)
+// ---------------------------------------------------------------------------
+let _activePlannerCtx = null;
+export function setActivePlannerContext(ctx) {
+    _activePlannerCtx = ctx;
+}
+export function clearActivePlannerContext() {
+    _activePlannerCtx = null;
+}
+function requireContext() {
+    if (!_activePlannerCtx) {
+        throw new Error("No active planning session. This tool is only available during planning mode.");
+    }
+    return _activePlannerCtx;
+}
+// ---------------------------------------------------------------------------
+// Identifier resolution
+// ---------------------------------------------------------------------------
+function buildIdentifierMap(issues) {
+    const map = new Map();
+    for (const issue of issues) {
+        map.set(issue.identifier, issue.id);
+    }
+    return map;
+}
+function resolveId(idMap, identifier) {
+    const id = idMap.get(identifier);
+    if (!id)
+        throw new Error(`Unknown issue identifier: ${identifier}. Use get_project_plan to see current issues.`);
+    return id;
+}
+// ---------------------------------------------------------------------------
+// DAG cycle detection (Kahn's algorithm)
+// ---------------------------------------------------------------------------
+export function detectCycles(issues) {
+    // Build adjacency: "blocks" means an edge from blocker to blocked
+    const identifiers = new Set(issues.map((i) => i.identifier));
+    const inDegree = new Map();
+    const adjacency = new Map();
+    for (const id of identifiers) {
+        inDegree.set(id, 0);
+        adjacency.set(id, []);
+    }
+    for (const issue of issues) {
+        for (const rel of issue.relations?.nodes ?? []) {
+            const target = rel.relatedIssue?.identifier;
+            if (!target || !identifiers.has(target))
+                continue;
+            if (rel.type === "blocks") {
+                // issue blocks target → edge from issue to target
+                adjacency.get(issue.identifier).push(target);
+                inDegree.set(target, (inDegree.get(target) ?? 0) + 1);
+            }
+            else if (rel.type === "blocked_by") {
+                // issue is blocked by target → edge from target to issue
+                adjacency.get(target).push(issue.identifier);
+                inDegree.set(issue.identifier, (inDegree.get(issue.identifier) ?? 0) + 1);
+            }
+        }
+    }
+    // Kahn's algorithm
+    const queue = [];
+    for (const [id, deg] of inDegree) {
+        if (deg === 0)
+            queue.push(id);
+    }
+    let processed = 0;
+    while (queue.length > 0) {
+        const node = queue.shift();
+        processed++;
+        for (const neighbor of adjacency.get(node) ?? []) {
+            const newDeg = (inDegree.get(neighbor) ?? 1) - 1;
+            inDegree.set(neighbor, newDeg);
+            if (newDeg === 0)
+                queue.push(neighbor);
+        }
+    }
+    // Nodes not processed are in cycles
+    if (processed === identifiers.size)
+        return [];
+    const cycleNodes = [];
+    for (const [id, deg] of inDegree) {
+        if (deg > 0)
+            cycleNodes.push(id);
+    }
+    return cycleNodes;
+}
+// ---------------------------------------------------------------------------
+// Audit logic
+// ---------------------------------------------------------------------------
+export function auditPlan(issues) {
+    const problems = [];
+    const warnings = [];
+    for (const issue of issues) {
+        const isEpic = issue.labels?.nodes?.some((l) => l.name.toLowerCase().includes("epic"));
+        // Description check
+        if (!issue.description || issue.description.trim().length < 50) {
+            problems.push(`${issue.identifier} "${issue.title}": description missing or too short (min 50 chars)`);
+        }
+        // Non-epic checks
+        if (!isEpic) {
+            if (issue.estimate == null) {
+                problems.push(`${issue.identifier} "${issue.title}": missing estimate`);
+            }
+            if (!issue.priority || issue.priority === 0) {
+                problems.push(`${issue.identifier} "${issue.title}": missing priority`);
+            }
+            // Acceptance criteria check (warning, not failure)
+            const acMarkers = /\b(given|when|then|as a|i want|so that|acceptance criteria|uat|test scenario)\b/i;
+            if (issue.description && !acMarkers.test(issue.description)) {
+                warnings.push(`${issue.identifier} "${issue.title}": no acceptance criteria or test scenarios found in description`);
+            }
+        }
+    }
+    // DAG cycle check
+    const cycleNodes = detectCycles(issues);
+    if (cycleNodes.length > 0) {
+        problems.push(`Dependency cycle detected involving: ${cycleNodes.join(", ")}`);
+    }
+    // Orphan check: issues with no parent and no relations linking to the rest
+    const hasParent = new Set(issues.filter((i) => i.parent).map((i) => i.identifier));
+    const hasRelation = new Set();
+    for (const issue of issues) {
+        for (const rel of issue.relations?.nodes ?? []) {
+            hasRelation.add(issue.identifier);
+            if (rel.relatedIssue?.identifier)
+                hasRelation.add(rel.relatedIssue.identifier);
+        }
+    }
+    for (const issue of issues) {
+        if (!hasParent.has(issue.identifier) && !hasRelation.has(issue.identifier)) {
+            warnings.push(`${issue.identifier} "${issue.title}": orphan issue (no parent or dependency links)`);
+        }
+    }
+    return {
+        pass: problems.length === 0,
+        problems,
+        warnings,
+    };
+}
+// ---------------------------------------------------------------------------
+// Snapshot formatter
+// ---------------------------------------------------------------------------
+export function buildPlanSnapshot(issues) {
+    if (issues.length === 0)
+        return "_No issues created yet._";
+    const lines = [];
+    const childMap = new Map();
+    const topLevel = [];
+    for (const issue of issues) {
+        if (issue.parent) {
+            const siblings = childMap.get(issue.parent.identifier) ?? [];
+            siblings.push(issue);
+            childMap.set(issue.parent.identifier, siblings);
+        }
+        else {
+            topLevel.push(issue);
+        }
+    }
+    const priorityLabel = (p) => {
+        if (p === 1)
+            return "Urgent";
+        if (p === 2)
+            return "High";
+        if (p === 3)
+            return "Medium";
+        if (p === 4)
+            return "Low";
+        return "None";
+    };
+    const formatRelations = (issue) => {
+        const rels = issue.relations?.nodes ?? [];
+        if (rels.length === 0)
+            return "";
+        return " " + rels.map((r) => `→ ${r.type} ${r.relatedIssue.identifier}`).join(", ");
+    };
+    const formatIssue = (issue, indent) => {
+        const est = issue.estimate != null ? `est: ${issue.estimate}` : "est: -";
+        const pri = `pri: ${priorityLabel(issue.priority)}`;
+        const rels = formatRelations(issue);
+        lines.push(`${indent}- ${issue.identifier} "${issue.title}" [${est}, ${pri}]${rels}`);
+        const children = childMap.get(issue.identifier) ?? [];
+        for (const child of children) {
+            formatIssue(child, indent + "  ");
+        }
+    };
+    // Separate epics from standalone issues
+    const epics = topLevel.filter((i) => i.labels?.nodes?.some((l) => l.name.toLowerCase().includes("epic")));
+    const standalone = topLevel.filter((i) => !i.labels?.nodes?.some((l) => l.name.toLowerCase().includes("epic")));
+    if (epics.length > 0) {
+        lines.push(`### Epics (${epics.length})`);
+        for (const epic of epics)
+            formatIssue(epic, "");
+    }
+    if (standalone.length > 0) {
+        lines.push(`### Standalone issues (${standalone.length})`);
+        for (const issue of standalone)
+            formatIssue(issue, "");
+    }
+    return lines.join("\n");
+}
+// ---------------------------------------------------------------------------
+// Tool factory
+// ---------------------------------------------------------------------------
+export function createPlannerTools() {
+    return [
+        // ---- create_issue ----
+        {
+            name: "plan_create_issue",
+            label: "Create Issue",
+            description: "Create a new Linear issue in the current planning project. Use parentIdentifier to create sub-issues under an epic or parent issue.",
+            parameters: {
+                type: "object",
+                properties: {
+                    title: { type: "string", description: "Issue title" },
+                    description: { type: "string", description: "Issue description including: user story (As a...), acceptance criteria (Given/When/Then), and at least one UAT test scenario (min 50 chars)" },
+                    parentIdentifier: { type: "string", description: "Parent issue identifier (e.g. PROJ-2) to create as sub-issue" },
+                    isEpic: { type: "boolean", description: "Mark as epic (high-level feature area)" },
+                    priority: { type: "number", description: "Priority: 1=Urgent, 2=High, 3=Medium, 4=Low" },
+                    estimate: { type: "number", description: "Story point estimate" },
+                },
+                required: ["title", "description"],
+            },
+            execute: async (_toolCallId, params) => {
+                const { linearApi, projectId, teamId } = requireContext();
+                const input = {
+                    teamId,
+                    projectId,
+                    title: params.title,
+                    description: params.description,
+                };
+                if (params.priority)
+                    input.priority = params.priority;
+                if (params.estimate != null)
+                    input.estimate = params.estimate;
+                // Resolve parent
+                if (params.parentIdentifier) {
+                    const issues = await linearApi.getProjectIssues(projectId);
+                    const idMap = buildIdentifierMap(issues);
+                    input.parentId = resolveId(idMap, params.parentIdentifier);
+                }
+                const result = await linearApi.createIssue(input);
+                // If epic, try to add "Epic" label
+                if (params.isEpic) {
+                    try {
+                        const labels = await linearApi.getTeamLabels(teamId);
+                        const epicLabel = labels.find((l) => l.name.toLowerCase() === "epic");
+                        if (epicLabel) {
+                            await linearApi.updateIssueExtended(result.id, { labelIds: [epicLabel.id] });
+                        }
+                    }
+                    catch { /* best-effort labeling */ }
+                }
+                return jsonResult({
+                    id: result.id,
+                    identifier: result.identifier,
+                    title: params.title,
+                    isEpic: params.isEpic ?? false,
+                });
+            },
+        },
+        // ---- link_issues ----
+        {
+            name: "plan_link_issues",
+            label: "Link Issues",
+            description: "Create a dependency relationship between two issues. Use 'blocks' to indicate ordering: if A must finish before B starts, A blocks B.",
+            parameters: {
+                type: "object",
+                properties: {
+                    fromIdentifier: { type: "string", description: "Source issue identifier (e.g. PROJ-2)" },
+                    toIdentifier: { type: "string", description: "Target issue identifier (e.g. PROJ-3)" },
+                    type: {
+                        type: "string",
+                        description: "Relationship type: 'blocks', 'blocked_by', or 'related'",
+                    },
+                },
+                required: ["fromIdentifier", "toIdentifier", "type"],
+            },
+            execute: async (_toolCallId, params) => {
+                const { linearApi, projectId } = requireContext();
+                const issues = await linearApi.getProjectIssues(projectId);
+                const idMap = buildIdentifierMap(issues);
+                const fromId = resolveId(idMap, params.fromIdentifier);
+                const toId = resolveId(idMap, params.toIdentifier);
+                const result = await linearApi.createIssueRelation({
+                    issueId: fromId,
+                    relatedIssueId: toId,
+                    type: params.type,
+                });
+                return jsonResult({
+                    id: result.id,
+                    from: params.fromIdentifier,
+                    to: params.toIdentifier,
+                    type: params.type,
+                });
+            },
+        },
+        // ---- get_project_plan ----
+        {
+            name: "plan_get_project",
+            label: "Get Project Plan",
+            description: "Retrieve the current project plan showing all issues organized by hierarchy with dependency relationships.",
+            parameters: {
+                type: "object",
+                properties: {},
+                required: [],
+            },
+            execute: async () => {
+                const { linearApi, projectId } = requireContext();
+                const issues = await linearApi.getProjectIssues(projectId);
+                const snapshot = buildPlanSnapshot(issues);
+                return jsonResult({
+                    issueCount: issues.length,
+                    plan: snapshot,
+                });
+            },
+        },
+        // ---- update_issue ----
+        {
+            name: "plan_update_issue",
+            label: "Update Issue",
+            description: "Update an existing issue's description, estimate, priority, or labels.",
+            parameters: {
+                type: "object",
+                properties: {
+                    identifier: { type: "string", description: "Issue identifier (e.g. PROJ-5)" },
+                    description: { type: "string", description: "New description" },
+                    estimate: { type: "number", description: "New estimate" },
+                    priority: { type: "number", description: "New priority: 1=Urgent, 2=High, 3=Medium, 4=Low" },
+                    labelIds: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "Label IDs to set",
+                    },
+                },
+                required: ["identifier"],
+            },
+            execute: async (_toolCallId, params) => {
+                const { linearApi, projectId } = requireContext();
+                const issues = await linearApi.getProjectIssues(projectId);
+                const idMap = buildIdentifierMap(issues);
+                const issueId = resolveId(idMap, params.identifier);
+                const updates = {};
+                if (params.description !== undefined)
+                    updates.description = params.description;
+                if (params.estimate !== undefined)
+                    updates.estimate = params.estimate;
+                if (params.priority !== undefined)
+                    updates.priority = params.priority;
+                if (params.labelIds !== undefined)
+                    updates.labelIds = params.labelIds;
+                const success = await linearApi.updateIssueExtended(issueId, updates);
+                return jsonResult({ identifier: params.identifier, updated: success });
+            },
+        },
+        // ---- audit_plan ----
+        {
+            name: "plan_audit",
+            label: "Audit Plan",
+            description: "Run a completeness audit on the current project plan. Checks descriptions, estimates, priorities, DAG validity, and orphan issues.",
+            parameters: {
+                type: "object",
+                properties: {},
+                required: [],
+            },
+            execute: async () => {
+                const { linearApi, projectId } = requireContext();
+                const issues = await linearApi.getProjectIssues(projectId);
+                const result = auditPlan(issues);
+                return jsonResult(result);
+            },
+        },
+    ];
+}

--- a/dist/src/tools/steering-tools.js
+++ b/dist/src/tools/steering-tools.js
@@ -1,0 +1,126 @@
+import { execSync } from "node:child_process";
+import { jsonResult } from "openclaw/plugin-sdk/core";
+import { getActiveTmuxSession } from "../infra/tmux-runner.js";
+import { capturePane, shellEscape } from "../infra/tmux.js";
+/**
+ * Create steering tools for interacting with active tmux agent sessions.
+ *
+ * - steer_agent: Send input to an active agent session via tmux send-keys
+ * - capture_agent_output: Capture recent output from an agent's tmux pane
+ * - abort_agent: Kill an active agent's tmux session
+ */
+export function createSteeringTools(api, _ctx) {
+    return [
+        {
+            name: "steer_agent",
+            label: "Steer Agent",
+            description: "Send a message to an active coding agent running in a tmux session. " +
+                "Use this to provide information, answer questions, or redirect the agent's approach.",
+            parameters: {
+                type: "object",
+                properties: {
+                    issueId: {
+                        type: "string",
+                        description: "The Linear issue ID of the active agent session.",
+                    },
+                    message: {
+                        type: "string",
+                        description: "The message to send to the agent.",
+                    },
+                },
+                required: ["issueId", "message"],
+            },
+            async execute(_toolCallId, params) {
+                const session = getActiveTmuxSession(params.issueId);
+                if (!session) {
+                    return jsonResult({ error: `No active tmux session for issue ${params.issueId}` });
+                }
+                if (session.steeringMode === "one-shot") {
+                    return jsonResult({
+                        error: `Agent ${session.backend} is in one-shot mode — steering via stdin is not supported.`,
+                    });
+                }
+                try {
+                    execSync(`tmux send-keys -t ${shellEscape(session.sessionName)} ${shellEscape(params.message)} Enter`, { stdio: "ignore", timeout: 5_000 });
+                    return jsonResult({
+                        success: true,
+                        sessionName: session.sessionName,
+                        backend: session.backend,
+                    });
+                }
+                catch (err) {
+                    return jsonResult({ error: `Failed to steer agent: ${err}` });
+                }
+            },
+        },
+        {
+            name: "capture_agent_output",
+            label: "Capture Agent Output",
+            description: "Capture the last 50 lines of output from an active coding agent's tmux session. " +
+                "Use this to see what the agent is currently doing before deciding how to steer it.",
+            parameters: {
+                type: "object",
+                properties: {
+                    issueId: {
+                        type: "string",
+                        description: "The Linear issue ID of the active agent session.",
+                    },
+                    lines: {
+                        type: "number",
+                        description: "Number of lines to capture (default: 50).",
+                    },
+                },
+                required: ["issueId"],
+            },
+            async execute(_toolCallId, params) {
+                const session = getActiveTmuxSession(params.issueId);
+                if (!session) {
+                    return jsonResult({ error: `No active tmux session for issue ${params.issueId}` });
+                }
+                try {
+                    const output = capturePane(session.sessionName, params.lines ?? 50);
+                    return jsonResult({
+                        sessionName: session.sessionName,
+                        backend: session.backend,
+                        output: output || "(empty pane)",
+                    });
+                }
+                catch (err) {
+                    return jsonResult({ error: `Failed to capture output: ${err}` });
+                }
+            },
+        },
+        {
+            name: "abort_agent",
+            label: "Abort Agent",
+            description: "Kill an active coding agent's tmux session. Use this when the user wants to stop a running agent.",
+            parameters: {
+                type: "object",
+                properties: {
+                    issueId: {
+                        type: "string",
+                        description: "The Linear issue ID of the active agent session.",
+                    },
+                },
+                required: ["issueId"],
+            },
+            async execute(_toolCallId, params) {
+                const session = getActiveTmuxSession(params.issueId);
+                if (!session) {
+                    return jsonResult({ error: `No active tmux session for issue ${params.issueId}` });
+                }
+                try {
+                    execSync(`tmux kill-session -t ${shellEscape(session.sessionName)}`, { stdio: "ignore", timeout: 5_000 });
+                    return jsonResult({
+                        success: true,
+                        killed: session.sessionName,
+                        backend: session.backend,
+                    });
+                }
+                catch (err) {
+                    return jsonResult({ error: `Failed to abort agent: ${err}` });
+                }
+            },
+        },
+    ];
+}

--- a/dist/src/tools/tools.js
+++ b/dist/src/tools/tools.js
@@ -1,0 +1,51 @@
+import { createCodeTools } from "./code-tool.js";
+import { createOrchestrationTools } from "./orchestration-tools.js";
+import { createLinearIssuesTool } from "./linear-issues-tool.js";
+import { createSteeringTools } from "./steering-tools.js";
+export function createLinearTools(api, ctx) {
+    const pluginConfig = api.pluginConfig;
+    // Per-backend coding CLI tools: cli_codex, cli_claude, cli_gemini
+    const codeTools = [];
+    try {
+        codeTools.push(...createCodeTools(api, ctx));
+    }
+    catch (err) {
+        api.logger.warn(`CLI coding tools not available: ${err}`);
+    }
+    // Orchestration tools (conditional on config — defaults to enabled)
+    const orchestrationTools = [];
+    const enableOrchestration = pluginConfig?.enableOrchestration !== false;
+    if (enableOrchestration) {
+        try {
+            orchestrationTools.push(...createOrchestrationTools(api, ctx));
+        }
+        catch (err) {
+            api.logger.warn(`Orchestration tools not available: ${err}`);
+        }
+    }
+    // Linear issue management — native GraphQL API tool
+    const linearIssuesTools = [];
+    try {
+        linearIssuesTools.push(createLinearIssuesTool(api));
+    }
+    catch (err) {
+        api.logger.warn(`linear_issues tool not available: ${err}`);
+    }
+    // Steering tools (steer/capture/abort active tmux agent sessions)
+    const steeringTools = [];
+    const enableTmux = pluginConfig?.enableTmux !== false;
+    if (enableTmux) {
+        try {
+            steeringTools.push(...createSteeringTools(api, ctx));
+        }
+        catch (err) {
+            api.logger.warn(`Steering tools not available: ${err}`);
+        }
+    }
+    return [
+        ...codeTools,
+        ...orchestrationTools,
+        ...linearIssuesTools,
+        ...steeringTools,
+    ];
+}

--- a/index.ts
+++ b/index.ts
@@ -346,8 +346,8 @@ export default function register(api: OpenClawPluginApi) {
 
   api.logger.info("Dispatch lifecycle hooks registered: agent_end, subagent_ended, session_start, session_end, after_compaction, before_reset");
 
-  // Inject recent dispatch history as context for worker/audit agents
-  api.on("before_agent_start", async (event: any, ctx: any) => {
+  // Inject recent dispatch history as context for worker/audit agents.
+  api.on("before_prompt_build", async (_event: any, ctx: any) => {
     try {
       const sessionKey = ctx?.sessionKey ?? "";
       if (!sessionKey.startsWith("linear-worker-") && !sessionKey.startsWith("linear-audit-")) return;

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3,6 +3,28 @@
   "name": "Linear Agent",
   "description": "Linear integration with OAuth support, agent pipeline, and webhook-driven AI agent lifecycle",
   "version": "0.9.24",
+  "activation": {
+    "onStartup": true
+  },
+  "contracts": {
+    "tools": [
+      "cli_codex",
+      "cli_claude",
+      "cli_gemini",
+      "spawn_agent",
+      "ask_agent",
+      "linear_issues",
+      "steer_agent",
+      "capture_agent_output",
+      "abort_agent",
+      "plan_create_issue",
+      "plan_link_issues",
+      "plan_get_project",
+      "plan_update_issue",
+      "plan_audit",
+      "dispatch_history"
+    ]
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -15,6 +37,9 @@
       "defaultAgentId": { "type": "string", "description": "OpenClaw agent ID to use for pipeline stages" },
       "enableAudit": { "type": "boolean", "description": "Run auditor stage after implementation", "default": true },
       "codexBaseRepo": { "type": "string", "description": "Path to git repo for Codex worktrees", "default": "/home/claw/ai-workspace" },
+      "codexBin": { "type": "string", "description": "Path to the Codex CLI binary used by codex_run diagnostics and tools" },
+      "claudeBin": { "type": "string", "description": "Path to the Claude CLI binary used by claude_run diagnostics and tools" },
+      "geminiBin": { "type": "string", "description": "Path to the Gemini CLI binary used by gemini_run diagnostics and tools" },
       "enableOrchestration": { "type": "boolean", "description": "Allow agents to spawn sub-agents via spawn_agent/ask_agent tools", "default": true },
       "worktreeBaseDir": { "type": "string", "description": "Base directory for persistent git worktrees (default: ~/.openclaw/worktrees)" },
       "repos": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@types/node": "^22.19.18",
         "@vitest/coverage-v8": "^4.0.18",
         "commander": "^14.0.3",
-        "openclaw": "^2026.5.9-beta.1",
+        "openclaw": "2026.6.1-beta.1",
         "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       },
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
-      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -176,9 +176,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -193,9 +193,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -210,9 +210,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -261,13 +261,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -278,13 +281,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -295,13 +301,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -312,13 +321,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -329,13 +341,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
-      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -346,13 +361,16 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -363,9 +381,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -380,9 +398,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -399,9 +417,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -416,9 +434,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -483,9 +501,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.19.19",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
-      "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -493,14 +511,14 @@
       }
     },
     "node_modules/@vitest/coverage-v8": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
-      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.8.tgz",
+      "integrity": "sha512-lt3kovsyHwYe00wq4D1ti0Z974fWj4NLp6siqiyEufUpyFwK9Yhi7rBhac9JL5aA0zoMrJqc4vYPZRUnI7l7nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bcoe/v8-coverage": "^1.0.2",
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.8",
         "ast-v8-to-istanbul": "^1.0.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
@@ -514,8 +532,8 @@
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
-        "@vitest/browser": "4.1.7",
-        "vitest": "4.1.7"
+        "@vitest/browser": "4.1.8",
+        "vitest": "4.1.8"
       },
       "peerDependenciesMeta": {
         "@vitest/browser": {
@@ -524,16 +542,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
-      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.8.tgz",
+      "integrity": "sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -542,13 +560,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
-      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.8.tgz",
+      "integrity": "sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.7",
+        "@vitest/spy": "4.1.8",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -569,9 +587,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
-      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.8.tgz",
+      "integrity": "sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -582,13 +600,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
-      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.8.tgz",
+      "integrity": "sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.7",
+        "@vitest/utils": "4.1.8",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -596,14 +614,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
-      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.8.tgz",
+      "integrity": "sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -612,9 +630,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
-      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.8.tgz",
+      "integrity": "sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -622,13 +640,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
-      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.8.tgz",
+      "integrity": "sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.7",
+        "@vitest/pretty-format": "4.1.8",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -647,9 +665,9 @@
       }
     },
     "node_modules/ast-v8-to-istanbul": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.2.tgz",
-      "integrity": "sha512-dKmJxJsGItLmc5CYZKuEjuG6GnBs6PG4gohMhyFOWKaNQoYCuRZJDECaBlHmcG0lv2wc2E0uU8lESmBEumC3DQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.3.tgz",
+      "integrity": "sha512-jCMQ6ZylLPudp0CDfBmQBZUsrh1/8psbmu9ibeVWKuHWD0YrH9YABwlKu5kVEFoT0GCQQW9Z/SxfuEbbkGQCRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -968,6 +986,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -989,6 +1010,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1010,6 +1034,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1031,6 +1058,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1155,62 +1185,67 @@
       "license": "MIT"
     },
     "node_modules/openclaw": {
-      "version": "2026.5.22",
-      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.5.22.tgz",
-      "integrity": "sha512-m+zgBELGbCHjWB1IWF5WSWNPr480cMKOMff2OF72c8A0AMD4hC/9+qwYtzjYmGkETcffnB711JymlVsQnh2Tow==",
+      "version": "2026.6.1-beta.1",
+      "resolved": "https://registry.npmjs.org/openclaw/-/openclaw-2026.6.1-beta.1.tgz",
+      "integrity": "sha512-2wZAkSCiLgXixmKGl3NRCYS00UvnTyXwjbeiXjMBiagxJ+ToydghilAokh8hP0FlzjVLX1f1HVe02Au9lRUriQ==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "0.22.1",
+        "@anthropic-ai/sdk": "0.100.1",
         "@clack/core": "1.3.1",
         "@clack/prompts": "1.4.0",
-        "@earendil-works/pi-agent-core": "0.75.4",
-        "@earendil-works/pi-ai": "0.75.4",
-        "@earendil-works/pi-coding-agent": "0.75.4",
-        "@earendil-works/pi-tui": "0.75.4",
-        "@google/genai": "2.5.0",
+        "@earendil-works/pi-tui": "0.78.0",
+        "@google/genai": "2.7.0",
         "@grammyjs/runner": "2.0.3",
         "@grammyjs/transformer-throttler": "1.2.1",
-        "@homebridge/ciao": "1.3.8",
+        "@homebridge/ciao": "1.3.9",
         "@lydell/node-pty": "1.2.0-beta.12",
+        "@mistralai/mistralai": "2.2.5",
         "@modelcontextprotocol/sdk": "1.29.0",
         "@mozilla/readability": "0.6.0",
-        "@openclaw/fs-safe": "0.2.7",
+        "@openclaw/fs-safe": "0.3.0",
         "@openclaw/proxyline": "0.3.3",
-        "ajv": "8.20.0",
         "chalk": "5.6.2",
         "chokidar": "5.0.0",
+        "clawpdf": "0.3.0",
         "commander": "14.0.3",
         "croner": "10.0.1",
+        "cross-spawn": "7.0.6",
+        "diff": "9.0.0",
         "dotenv": "17.4.2",
         "express": "5.2.1",
         "file-type": "22.0.1",
+        "glob": "13.0.6",
         "grammy": "1.43.0",
-        "ipaddr.js": "2.4.0",
+        "highlight.js": "11.11.1",
+        "hosted-git-info": "10.1.1",
+        "ignore": "7.0.5",
         "jiti": "2.7.0",
         "json5": "2.2.3",
         "jszip": "3.10.1",
         "kysely": "0.29.2",
         "linkedom": "0.18.12",
-        "markdown-it": "14.1.1",
+        "minimatch": "10.2.5",
         "node-edge-tts": "1.2.10",
-        "openai": "6.38.0",
-        "pdfjs-dist": "5.7.284",
+        "openai": "6.39.1",
+        "partial-json": "0.1.7",
         "playwright-core": "1.60.0",
+        "proper-lockfile": "4.1.2",
         "qrcode": "1.5.4",
-        "quickjs-wasi": "2.2.0",
+        "quickjs-wasi": "3.0.0",
+        "rastermill": "0.3.1",
         "tar": "7.5.15",
-        "tokenjuice": "0.7.1",
         "tree-sitter-bash": "0.25.1",
         "tslog": "4.10.2",
-        "typebox": "1.1.38",
+        "typebox": "1.1.39",
         "typescript": "6.0.3",
         "undici": "8.3.0",
         "web-push": "3.6.7",
         "web-tree-sitter": "0.26.9",
-        "ws": "8.20.1",
+        "ws": "8.21.0",
         "yaml": "2.9.0",
         "zod": "4.4.3"
       },
@@ -1221,7 +1256,6 @@
         "node": ">=22.19.0"
       },
       "optionalDependencies": {
-        "sharp": "0.34.5",
         "sqlite-vec": "0.1.9"
       }
     },
@@ -1236,9 +1270,9 @@
       }
     },
     "node_modules/openclaw/node_modules/@anthropic-ai/sdk": {
-      "version": "0.97.1",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.97.1.tgz",
-      "integrity": "sha512-wOf7AUeJPitcVpvKO4UMu63mWH5SaVipkGd7OOQJt/G6VYGlV8D2Gp9dLxOrttDJh/9gqPqdaBwDGcBevumeAg==",
+      "version": "0.100.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.100.1.tgz",
+      "integrity": "sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1257,459 +1291,10 @@
         }
       }
     },
-    "node_modules/openclaw/node_modules/@aws-crypto/crc32": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
-      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/client-bedrock-runtime": {
-      "version": "3.1051.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-bedrock-runtime/-/client-bedrock-runtime-3.1051.0.tgz",
-      "integrity": "sha512-Hf532hBUIq/QqtGrKnWxHhw4rGpzTAGA7hG5c+IlOY0z8pqrqNXdwLjSve6ClOg8/Lxdvo+E81VzFVtl03v97A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/credential-provider-node": "^3.972.43",
-        "@aws-sdk/eventstream-handler-node": "^3.972.16",
-        "@aws-sdk/middleware-eventstream": "^3.972.12",
-        "@aws-sdk/middleware-websocket": "^3.972.20",
-        "@aws-sdk/token-providers": "3.1051.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/core": {
-      "version": "3.974.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.12.tgz",
-      "integrity": "sha512-qrqgioqYFjwR6LatVNS1L2Vk++EwRIxqSQXPKNv5Ofux2D8UNgqMQ1znnMyEImXquVPTtbf71fc128pvmU6y9A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@aws-sdk/xml-builder": "^3.972.24",
-        "@aws/lambda-invoke-store": "^0.2.2",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.38.tgz",
-      "integrity": "sha512-m3WjZEgPtioMhPmwqUt+DhlTJ2i9ufR6DhfkyXojb9puEvfR+ur2U5shavu5/Cc9WHHsDCvALi6UFHgcqjhQ5w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.40.tgz",
-      "integrity": "sha512-D78L/m2Dr6cJnnSvWoAudPhQmCwmJ7j6APXsPYmFpPaKfQTfCSu0rdm8j14Np+VmXF9z8Aj8HE3xFpsrwtfgeg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.42.tgz",
-      "integrity": "sha512-Mu5ESvFXeinafVM8jTIvRqcvK2Ehj4kz3auT39yUcHwu1Vfxo6xRlmUafdKLW4tusjAJukQwK09sCSMgOm7OKg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/credential-provider-env": "^3.972.38",
-        "@aws-sdk/credential-provider-http": "^3.972.40",
-        "@aws-sdk/credential-provider-login": "^3.972.42",
-        "@aws-sdk/credential-provider-process": "^3.972.38",
-        "@aws-sdk/credential-provider-sso": "^3.972.42",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.42.tgz",
-      "integrity": "sha512-O6WkZga3kf0yqyJYd1dbeJqVhEgJx/x1UaLgtbR+XuL/YP+K5y6QTxQKL7ka9z3jnQASESKGAPnRyt4D5hQrxA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.43.tgz",
-      "integrity": "sha512-D/DJmbrWRP5BXEO3FH+ar4el+2n6OlGofiud7dQun2jES+AQEJjczenp1jBb4MBN7CpGpS8nsWGQLtuzc9tQbA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.38",
-        "@aws-sdk/credential-provider-http": "^3.972.40",
-        "@aws-sdk/credential-provider-ini": "^3.972.42",
-        "@aws-sdk/credential-provider-process": "^3.972.38",
-        "@aws-sdk/credential-provider-sso": "^3.972.42",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.42",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/credential-provider-imds": "^4.3.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.38.tgz",
-      "integrity": "sha512-EnbYVajGgbkb24s0K1eo4VNAPV5mHIET7LSvirTaFCwkfrfaOJxtSE+wY/tJdKDS21cEYkZs2ruCaAm+W4iblg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.42.tgz",
-      "integrity": "sha512-RVV/9NbFwI8ZHEH5dn39lGyFmSbSVj1+orZdr6QsOe1mW9DCglmlen0cFaNZmCcqkqc7erNRHNBduxbeZuHAnw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/token-providers": "3.1049.0",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1049.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1049.0.tgz",
-      "integrity": "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.42.tgz",
-      "integrity": "sha512-/67fXX0ddllD4u2Nujc5PvT4byHgpMUfz6+RxIKi/0nFIckeorm7JvXgzBuDyVKw0s58EbofmETDWUf9vTEuHQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.16",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.16.tgz",
-      "integrity": "sha512-yedpPgKftqjU5SlPFHfqWpOw6xSCRieWRG1euWOlXn4WJxt2VX92VprCa2PpSOXjVCAeK6dTjW9eJRXVig9yGA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.12.tgz",
-      "integrity": "sha512-tHTHHCHNrq6XklQvlzHBDJG4Iuhh7NVPRdtmvP+nHFA+5sxPlIDzlAHHgfoYHGvT3NXP1yVP/L5c3opUn6T3Qg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.20",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.20.tgz",
-      "integrity": "sha512-LM6P0i+Lu6pi25oNw2nqxjRxiEOtLgPB7xIvHfa+FxHTRLg8wcgqu3qg2COl4QaT7Es2yCxYdeRLVYazKAwL8g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.10.tgz",
-      "integrity": "sha512-FtQ/Bt327peZJuyo4WZSOLVUTw9ujRxntepiC7L65FxA2P82Xlq0g14T22BuqBUeMjDoxa9nvwiMHjLIfP3eUg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.27",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/fetch-http-handler": "^5.4.2",
-        "@smithy/node-http-handler": "^4.7.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.27.tgz",
-      "integrity": "sha512-0Phbz4t6HI3D3skxvG2uI+VWU034/nSIw1T8d+FPzzQG9EQTrw94o9mOKO2Gv3n3Oc8P7JD7RAUxkoneLWv5Eg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/signature-v4": "^5.4.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1051.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1051.0.tgz",
-      "integrity": "sha512-VRHgswmx5IVJknXy+mYoESj/coTj0lQ0Bw9WsFmtiLuLiWN1ipzG742/kmEGjKjytuy8vU5OQmpfXQGrmcHcGQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-sdk/core": "^3.974.12",
-        "@aws-sdk/nested-clients": "^3.997.10",
-        "@aws-sdk/types": "^3.973.8",
-        "@smithy/core": "^3.24.2",
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/types": {
-      "version": "3.973.8",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
-      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.14.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
-      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.24",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.24.tgz",
-      "integrity": "sha512-V8z5YcDPfsvzrBlj0xR1vhRtocblhYbqdreCJB/voGd4Sr5zjNAeWxexbnqVtskTJe0vFb5KMqbSL++ePl+zRw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@nodable/entities": "2.1.0",
-        "@smithy/types": "^4.14.1",
-        "fast-xml-parser": "5.7.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@aws/lambda-invoke-store": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
-      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
     "node_modules/openclaw/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
-      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1757,132 +1342,10 @@
         "node": ">= 20.12.0"
       }
     },
-    "node_modules/openclaw/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.75.4.tgz",
-      "integrity": "sha512-cGYbysb4EqUf0B28OeqFq2ppm1XF3bYBOP71q9dv38yf/UJfzMjiXBeNelrcio+QWIoVrW+xzYm7sMzYIUc9Og==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-ai": "^0.75.4",
-        "ignore": "7.0.5",
-        "typebox": "1.1.38",
-        "yaml": "2.9.0"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@earendil-works/pi-ai": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.75.4.tgz",
-      "integrity": "sha512-m/w8Hh3vQ0rAycwJiJWdzkypkn4295f4eq/966lDRy8aX5sk6bgYXH8TQmL16TO7Uwc7MbJG0QoyFHgX8RqXUQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@anthropic-ai/sdk": "0.91.1",
-        "@aws-sdk/client-bedrock-runtime": "3.1048.0",
-        "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
-        "http-proxy-agent": "7.0.2",
-        "https-proxy-agent": "7.0.6",
-        "openai": "6.26.0",
-        "partial-json": "0.1.7",
-        "typebox": "1.1.38"
-      },
-      "bin": {
-        "pi-ai": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@earendil-works/pi-ai/node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openclaw/node_modules/@earendil-works/pi-ai/node_modules/openai": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.26.0.tgz",
-      "integrity": "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "openai": "bin/cli"
-      },
-      "peerDependencies": {
-        "ws": "^8.18.0",
-        "zod": "^3.25 || ^4.0"
-      },
-      "peerDependenciesMeta": {
-        "ws": {
-          "optional": true
-        },
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/openclaw/node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.75.4.tgz",
-      "integrity": "sha512-Fb+FRo08b5H9pYKbQJ708/5OKL0+K/yclhfCMEhrBzSPTZZ4c85nY1YsBo4qwL20ohBMlBezHMRuHzcJ1ylEoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.75.4",
-        "@earendil-works/pi-ai": "^0.75.4",
-        "@earendil-works/pi-tui": "^0.75.4",
-        "@silvia-odwyer/photon-node": "0.3.4",
-        "chalk": "5.6.2",
-        "cross-spawn": "7.0.6",
-        "diff": "8.0.4",
-        "glob": "13.0.6",
-        "highlight.js": "10.7.3",
-        "hosted-git-info": "9.0.3",
-        "ignore": "7.0.5",
-        "jiti": "2.7.0",
-        "minimatch": "10.2.5",
-        "proper-lockfile": "4.1.2",
-        "typebox": "1.1.38",
-        "undici": "8.3.0",
-        "yaml": "2.9.0"
-      },
-      "bin": {
-        "pi": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=22.19.0"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard": "0.3.6"
-      }
-    },
     "node_modules/openclaw/node_modules/@earendil-works/pi-tui": {
-      "version": "0.75.4",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.75.4.tgz",
-      "integrity": "sha512-PDhKU7u6fmEcvHUFHzrRwGc/Ytokj/hO+X4RPf+MWKEGpvg3B1vHv88Ee+Dy33004tYkQF5YeXV4btJZcp5x1g==",
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.78.0.tgz",
+      "integrity": "sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1891,26 +1354,12 @@
       },
       "engines": {
         "node": ">=22.19.0"
-      },
-      "optionalDependencies": {
-        "koffi": "2.16.2"
-      }
-    },
-    "node_modules/openclaw/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/openclaw/node_modules/@google/genai": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.5.0.tgz",
-      "integrity": "sha512-qDi3LLh9I3llJK0f9uV8kZ8EdT9oHPxGJJ9yOJ/i5YXYrVwRCs8jHo9x4e99uOeKYDvD3TZwT70p/H/LS3BixQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.7.0.tgz",
+      "integrity": "sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1972,9 +1421,9 @@
       "license": "MIT"
     },
     "node_modules/openclaw/node_modules/@homebridge/ciao": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.8.tgz",
-      "integrity": "sha512-lNhpCsZVbdbjz2trFjQdzQ3cUIMZQMIMksi7wd3ntTIYgdaGLqT1Ms97DfVIJYHzRuduf56ISvgU8RRLTpK/ng==",
+      "version": "1.3.9",
+      "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.9.tgz",
+      "integrity": "sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1998,497 +1447,6 @@
       },
       "peerDependencies": {
         "hono": "^4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/colour": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
-      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/openclaw/node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND LGPL-3.0-or-later",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/openclaw/node_modules/@isaacs/fs-minipass": {
@@ -2603,200 +1561,10 @@
         "win32"
       ]
     },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard/-/clipboard-0.3.6.tgz",
-      "integrity": "sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "optionalDependencies": {
-        "@mariozechner/clipboard-darwin-arm64": "0.3.6",
-        "@mariozechner/clipboard-darwin-universal": "0.3.6",
-        "@mariozechner/clipboard-darwin-x64": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-arm64-musl": "0.3.6",
-        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-gnu": "0.3.6",
-        "@mariozechner/clipboard-linux-x64-musl": "0.3.6",
-        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.6",
-        "@mariozechner/clipboard-win32-x64-msvc": "0.3.6"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-darwin-arm64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.6.tgz",
-      "integrity": "sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-darwin-universal": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.6.tgz",
-      "integrity": "sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-darwin-x64": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.6.tgz",
-      "integrity": "sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.6.tgz",
-      "integrity": "sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-linux-arm64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.6.tgz",
-      "integrity": "sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.6.tgz",
-      "integrity": "sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-linux-x64-gnu": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.6.tgz",
-      "integrity": "sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-linux-x64-musl": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.6.tgz",
-      "integrity": "sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.6.tgz",
-      "integrity": "sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/openclaw/node_modules/@mariozechner/clipboard-win32-x64-msvc": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.6.tgz",
-      "integrity": "sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
     "node_modules/openclaw/node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.5.tgz",
+      "integrity": "sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2856,285 +1624,10 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.100.tgz",
-      "integrity": "sha512-xglYA6q3XO5P3BNJYxVZ1IV7DLVjp1Py6nwag88YntrS+3vKHyYcMqXVS4ZztJmwz2uGvz1FWhI/4LgbR5uQDA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "workspaces": [
-        "e2e/*"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas-android-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-arm64": "0.1.100",
-        "@napi-rs/canvas-darwin-x64": "0.1.100",
-        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
-        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
-        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
-        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
-        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-android-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
-      "integrity": "sha512-hjhCKhntPv9+t4ckHymdx0phYNcVW+GKQR6Lzw2zE+pOVjOplSmtx9nNNknTjbEDLcuLZqA1y8ufKg1XfgftzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-darwin-arm64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
-      "integrity": "sha512-2PcswRaC7Ly645DGt88///zuFDhJxJYdKAs1uU3mfk1atYkXufgcgLfBpk6Tm12nCQBaNt1wpybuPZ4qOhTo8A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-darwin-x64": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
-      "integrity": "sha512-ePNZtj7pNIva/siZMg+HmbeozkIjqUIYdoymH8HaA3qK7LfzFN4WMBM8G6HQ9ZC+H3+Dnn5pqtiXpgLykaPOhw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
-      "integrity": "sha512-d5cDB48oWFGU8/XPhUOFAlySgb/VAu7D+s8fi55K1Pcfg8aPplHWqMgibhVLU8ky7Pyg/fuiVLz4Nf3JrSTuUA==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-linux-arm64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
-      "integrity": "sha512-rDxgxRu69RvDlX/bh9o22DxLsGr8EqsNgotL9+RwQE1S0b0cqeatqsw6aW45mukm0B42DIAaAacKaYQ8cqS1nw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-linux-arm64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
-      "integrity": "sha512-K3mDW66N+xT2/V439u1alFANiBUjdEx2gLiNYnCmUsva5jZMxWTjafBYwTzYK+EMFMHrUoabuU+T1BIP5CgbYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
-      "integrity": "sha512-mooqUBTIsccZpnoQC4NgrC1v6C1vof39etLNMnBwCY+p0gajWJvAHLGQ6g/gGyS5YrpDW+GefSN4+Cvcr08UWw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-linux-x64-gnu": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
-      "integrity": "sha512-1eCvkDCazm7FFhsT7DfGOdSaHgZVK3bt/dSBl5EWHOWmnz+I7j8tPseJqqD81NF+MH21jKUK4wQSDjN0mdhnTg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-linux-x64-musl": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
-      "integrity": "sha512-20arT6lnI19S68qNlii73TSEDbECNgzMz2EpldC1V3mZFuRkeujXkcebRk0LRJe9SEUAooYiLokfMViY8IX7yA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-win32-arm64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
-      "integrity": "sha512-DZFFT1wIAg37LJw37yhMRFfjATd3vTQzjZ1Yki8u2vhO6Hi5VE6BVaGQ1aaDu7xb4iMErz+9EOwjpS7xcxFeBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@napi-rs/canvas-win32-x64-msvc": {
-      "version": "0.1.100",
-      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
-      "integrity": "sha512-MyT1j3mHC2+Lu4pBi9mKyMJhtP6U7k7EldY7sj/uS5gJA65gTXt8MefJQXLJo5d/vZbuWmfxzkEUNc/urV3pHA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      }
-    },
-    "node_modules/openclaw/node_modules/@nodable/entities": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodable"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/openclaw/node_modules/@openclaw/fs-safe": {
-      "version": "0.2.7",
-      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.2.7.tgz",
-      "integrity": "sha512-l/Yj3K2ChR/gI+bZo1wIe7rjKyTFwGOAw120cTCMRT8LZbVhJhTbiZLGIRBMv0Gc9GQjYE8EjPBza3RdrSSbyQ==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@openclaw/fs-safe/-/fs-safe-0.3.0.tgz",
+      "integrity": "sha512-uIBE441CIt1kIURoP9qRGKZ8LkGyfD9ZzeESjwAd29ZPWtghws/5GR3Pjb67jKdcJHP1I6roNXcvnhzAU7lHlA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3164,135 +1657,6 @@
       "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/openclaw/node_modules/@smithy/core": {
-      "version": "3.24.3",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.3.tgz",
-      "integrity": "sha512-Ep/7tPamGY8mgESE3LyLKtxJyy6U52WWAqr/3wial47Sj4u3PiIF73AOGI27UyLy9duTkhZbgzodOfLV4TduZg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/credential-provider-imds": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.3.tgz",
-      "integrity": "sha512-I2Bti0DKFo2IJyN28ijCsx51BAumEYR4/1yZ1FXyBygy9MqbnMqCev4JPth/MbpRfBSRAX35hITSnAdJRo1u5w==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/fetch-http-handler": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.3.tgz",
-      "integrity": "sha512-F+DRf8IJazRJgYog2A/yJK7eYVc0rqTlRzO+5ZxjJd4WkZoKz0IJRncf7G6t1pdVT3kryJcwuTFhN1c5m6N47A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/is-array-buffer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
-      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/node-http-handler": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.3.tgz",
-      "integrity": "sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/signature-v4": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.3.tgz",
-      "integrity": "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/core": "^3.24.3",
-        "@smithy/types": "^4.14.2",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/types": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-      "integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/util-buffer-from": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
-      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/is-array-buffer": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
     },
     "node_modules/openclaw/node_modules/@stablelib/base64": {
       "version": "1.0.1",
@@ -3327,9 +1691,9 @@
       "license": "MIT"
     },
     "node_modules/openclaw/node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.5.tgz",
+      "integrity": "sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3431,13 +1795,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/openclaw/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/openclaw/node_modules/asn1.js": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
@@ -3535,13 +1892,6 @@
       "version": "2.19.5",
       "resolved": "https://registry.npmjs.org/bottleneck/-/bottleneck-2.19.5.tgz",
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/openclaw/node_modules/bowser": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
-      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3660,6 +2010,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/openclaw/node_modules/clawpdf": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/clawpdf/-/clawpdf-0.3.0.tgz",
+      "integrity": "sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "clawpdf": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/openclaw/node_modules/cliui": {
@@ -3896,21 +2259,10 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/openclaw/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/openclaw/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -4079,9 +2431,9 @@
       }
     },
     "node_modules/openclaw/node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4142,9 +2494,9 @@
       }
     },
     "node_modules/openclaw/node_modules/eventsource-parser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
-      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4277,45 +2629,6 @@
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
-      }
-    },
-    "node_modules/openclaw/node_modules/fast-xml-builder": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "path-expression-matcher": "^1.5.0",
-        "xml-naming": "^0.1.0"
-      }
-    },
-    "node_modules/openclaw/node_modules/fast-xml-parser": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.0.tgz",
-      "integrity": "sha512-MTcrUoRQ1GSQ9iG3QJzBGquYYYeA7piZaJoIWbPFGbRn6Jj6z7xgoAyi4DrZX4y2ZIQQBF59gc/zmvvejjgoFQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@nodable/entities": "^2.1.0",
-        "fast-xml-builder": "^1.1.5",
-        "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/openclaw/node_modules/fetch-blob": {
@@ -4649,9 +2962,9 @@
       }
     },
     "node_modules/openclaw/node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4662,13 +2975,13 @@
       }
     },
     "node_modules/openclaw/node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
-        "node": "*"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/openclaw/node_modules/hono": {
@@ -4682,16 +2995,16 @@
       }
     },
     "node_modules/openclaw/node_modules/hosted-git-info": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
-      "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-10.1.1.tgz",
+      "integrity": "sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "lru-cache": "^11.1.0"
       },
       "engines": {
-        "node": "^20.17.0 || >=22.9.0"
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
       }
     },
     "node_modules/openclaw/node_modules/html-escaper": {
@@ -4763,20 +3076,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/openclaw/node_modules/http-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.0",
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/openclaw/node_modules/https-proxy-agent": {
@@ -4866,13 +3165,13 @@
       }
     },
     "node_modules/openclaw/node_modules/ipaddr.js": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
-      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 10"
+        "node": ">= 0.10"
       }
     },
     "node_modules/openclaw/node_modules/is-fullwidth-code-point": {
@@ -5013,18 +3312,6 @@
         "safe-buffer": "^5.0.1"
       }
     },
-    "node_modules/openclaw/node_modules/koffi": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koffi/-/koffi-2.16.2.tgz",
-      "integrity": "sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "url": "https://liberapay.com/Koromix"
-      }
-    },
     "node_modules/openclaw/node_modules/kysely": {
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.29.2.tgz",
@@ -5070,16 +3357,6 @@
         }
       }
     },
-    "node_modules/openclaw/node_modules/linkify-it": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uc.micro": "^2.0.0"
-      }
-    },
     "node_modules/openclaw/node_modules/locate-path": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -5101,31 +3378,13 @@
       "license": "Apache-2.0"
     },
     "node_modules/openclaw/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
-      }
-    },
-    "node_modules/openclaw/node_modules/markdown-it": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-      "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.0",
-        "mdurl": "^2.0.0",
-        "punycode.js": "^2.3.1",
-        "uc.micro": "^2.1.0"
-      },
-      "bin": {
-        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/openclaw/node_modules/marked": {
@@ -5150,13 +3409,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/openclaw/node_modules/mdurl": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
-      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/openclaw/node_modules/media-typer": {
       "version": "1.1.0",
@@ -5282,9 +3534,9 @@
       }
     },
     "node_modules/openclaw/node_modules/node-addon-api": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.7.0.tgz",
-      "integrity": "sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
+      "integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5408,9 +3660,9 @@
       }
     },
     "node_modules/openclaw/node_modules/openai": {
-      "version": "6.38.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.38.0.tgz",
-      "integrity": "sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==",
+      "version": "6.39.1",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.39.1.tgz",
+      "integrity": "sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -5516,22 +3768,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/openclaw/node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/openclaw/node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -5568,19 +3804,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/openclaw/node_modules/pdfjs-dist": {
-      "version": "5.7.284",
-      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.7.284.tgz",
-      "integrity": "sha512-h4EdYQczmGhbOlqc3PPZwxevn7ApdWPbovAuWXOB/DjIyigSnwfy2oze7c6mRcSr9XgLp3eN3EeL4DyySTPMFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=22.13.0 || >=24"
-      },
-      "optionalDependencies": {
-        "@napi-rs/canvas": "^0.1.100"
       }
     },
     "node_modules/openclaw/node_modules/pkce-challenge": {
@@ -5673,26 +3896,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/openclaw/node_modules/proxy-addr/node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/openclaw/node_modules/punycode.js": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
-      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/openclaw/node_modules/qrcode": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
@@ -5783,9 +3986,9 @@
       }
     },
     "node_modules/openclaw/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5799,9 +4002,9 @@
       }
     },
     "node_modules/openclaw/node_modules/quickjs-wasi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-2.2.0.tgz",
-      "integrity": "sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickjs-wasi/-/quickjs-wasi-3.0.0.tgz",
+      "integrity": "sha512-X7ouKC4ZVf9bXQ8rsE7+L6TeBbesejAJH61x16xRaGAQGfBHHRcniWgzJZZVtHc8rS9yVsY+Tvk8/usAosg4bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5813,6 +4016,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/openclaw/node_modules/rastermill": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/rastermill/-/rastermill-0.3.1.tgz",
+      "integrity": "sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@silvia-odwyer/photon-node": "0.3.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/openclaw/node_modules/raw-body": {
@@ -5950,20 +4166,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/openclaw/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/openclaw/node_modules/send": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
@@ -6031,52 +4233,6 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/openclaw/node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      },
-      "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
-      }
     },
     "node_modules/openclaw/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -6363,19 +4519,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/openclaw/node_modules/strnum": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
-      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/openclaw/node_modules/strtok3": {
       "version": "10.3.5",
       "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
@@ -6437,23 +4580,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/openclaw/node_modules/tokenjuice": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/tokenjuice/-/tokenjuice-0.7.1.tgz",
-      "integrity": "sha512-eO048hm9UcGHASjYkIWEij8QN68amGp+S1nJyo685qB1/ol+VGEYjPglcVPvCbJbZyFHvI+BBAMvOfnqYCtpsQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tokenjuice": "dist/cli/main.js"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/vincentkoc"
       }
     },
     "node_modules/openclaw/node_modules/tr46": {
@@ -6544,9 +4670,9 @@
       }
     },
     "node_modules/openclaw/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.1.39",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.39.tgz",
+      "integrity": "sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6563,13 +4689,6 @@
       "engines": {
         "node": ">=14.17"
       }
-    },
-    "node_modules/openclaw/node_modules/uc.micro": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
-      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/openclaw/node_modules/uhyphen": {
       "version": "0.2.0",
@@ -6732,9 +4851,9 @@
       "license": "ISC"
     },
     "node_modules/openclaw/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6751,22 +4870,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/openclaw/node_modules/xml-naming": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=16.0.0"
       }
     },
     "node_modules/openclaw/node_modules/y18n": {
@@ -6911,13 +5014,13 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
-      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.132.0",
+        "@oxc-project/types": "=0.133.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
@@ -6927,21 +5030,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.2",
-        "@rolldown/binding-darwin-arm64": "1.0.2",
-        "@rolldown/binding-darwin-x64": "1.0.2",
-        "@rolldown/binding-freebsd-x64": "1.0.2",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
-        "@rolldown/binding-linux-arm64-musl": "1.0.2",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-gnu": "1.0.2",
-        "@rolldown/binding-linux-x64-musl": "1.0.2",
-        "@rolldown/binding-openharmony-arm64": "1.0.2",
-        "@rolldown/binding-wasm32-wasi": "1.0.2",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
-        "@rolldown/binding-win32-x64-msvc": "1.0.2"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/semver": {
@@ -7015,9 +5118,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7071,17 +5174,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
-      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
         "postcss": "^8.5.15",
-        "rolldown": "1.0.2",
-        "tinyglobby": "^0.2.16"
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -7149,19 +5252,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.7",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
-      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.8.tgz",
+      "integrity": "sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.7",
-        "@vitest/mocker": "4.1.7",
-        "@vitest/pretty-format": "4.1.7",
-        "@vitest/runner": "4.1.7",
-        "@vitest/snapshot": "4.1.7",
-        "@vitest/spy": "4.1.7",
-        "@vitest/utils": "4.1.7",
+        "@vitest/expect": "4.1.8",
+        "@vitest/mocker": "4.1.8",
+        "@vitest/pretty-format": "4.1.8",
+        "@vitest/runner": "4.1.8",
+        "@vitest/snapshot": "4.1.8",
+        "@vitest/spy": "4.1.8",
+        "@vitest/utils": "4.1.8",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -7189,12 +5292,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.7",
-        "@vitest/browser-preview": "4.1.7",
-        "@vitest/browser-webdriverio": "4.1.7",
-        "@vitest/coverage-istanbul": "4.1.7",
-        "@vitest/coverage-v8": "4.1.7",
-        "@vitest/ui": "4.1.7",
+        "@vitest/browser-playwright": "4.1.8",
+        "@vitest/browser-preview": "4.1.8",
+        "@vitest/browser-webdriverio": "4.1.8",
+        "@vitest/coverage-istanbul": "4.1.8",
+        "@vitest/coverage-v8": "4.1.8",
+        "@vitest/ui": "4.1.8",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -7256,9 +5359,9 @@
       }
     },
     "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
     "node": ">=22.16"
   },
   "files": [
-    "index.ts",
+    "dist/",
     "src/",
     "openclaw.plugin.json",
     "prompts.yaml",
     "README.md"
   ],
   "scripts": {
+    "build": "tsc --noEmit false --outDir dist",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
@@ -41,13 +42,13 @@
     "@types/node": "^22.19.18",
     "@vitest/coverage-v8": "^4.0.18",
     "commander": "^14.0.3",
-    "openclaw": "^2026.5.9-beta.1",
+    "openclaw": "2026.6.1-beta.1",
     "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },
   "openclaw": {
     "extensions": [
-      "./index.ts"
+      "./dist/index.js"
     ]
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- switch the plugin package entrypoint to built `dist/` output and add a `build` script
- pin the OpenClaw dev SDK to `2026.6.1-beta.1` for the latest runtime contract surface
- declare startup activation, tool contracts, and CLI binary config keys in `openclaw.plugin.json`
- move dispatch-history context injection from `before_agent_start` to `before_prompt_build`

## Verification
- `npm run build`
- `npm run typecheck`
- `npm test` — 42 files / 1202 tests passed
- stable compatibility probe with `openclaw@2026.5.28`: `npm run typecheck` and `npm test` passed in a temp copy
