### PR TITLE
fix: route AgentSession @mentions with global regex

### DIFF
--- a/dist/src/infra/shared-profiles.js
+++ b/dist/src/infra/shared-profiles.js
@@ -54,6 +54,8 @@ export function buildMentionPattern(profiles) {
  * belongs to. Returns { agentId, label } or null if no match.
  */
 export function resolveAgentFromAlias(alias, profiles) {
+    if (typeof alias !== "string" || alias.length === 0)
+        return null;
     const lower = alias.toLowerCase();
     for (const [agentId, profile] of Object.entries(profiles)) {
         if (profile.mentionAliases.some(a => a.toLowerCase() === lower)) {

--- a/dist/src/pipeline/webhook.js
+++ b/dist/src/pipeline/webhook.js
@@ -366,7 +366,10 @@ export async function handleLinearWebhook(api, req, res) {
                 mentionPattern.lastIndex = 0;
                 const mentionMatch = text.match(mentionPattern);
                 if (mentionMatch) {
-                    const alias = mentionMatch[1];
+                    // buildMentionPattern is global, so String#match returns full matches
+                    // rather than capture groups. Use the first full mention consistently
+                    // with both global and non-global patterns.
+                    const alias = mentionMatch[0]?.replace(/^@/, "");
                     const resolved = resolveAgentFromAlias(alias, profiles);
                     if (resolved) {
                         api.logger.info(`AgentSession routed to ${resolved.agentId} via @${alias} mention in ${text === userMessage ? "comment" : text === sessionPrompt ? "session prompt" : "promptContext"}`);
@@ -673,7 +676,8 @@ export async function handleLinearWebhook(api, req, res) {
         if (promptedMentionPattern && userMessage) {
             const mentionMatch = userMessage.match(promptedMentionPattern);
             if (mentionMatch) {
-                const alias = mentionMatch[1];
+                // A global mention regex returns full matches only, not capture groups.
+                const alias = mentionMatch[0]?.replace(/^@/, "");
                 const resolved = resolveAgentFromAlias(alias, promptedProfiles);
                 if (resolved) {
                     api.logger.info(`AgentSession prompted: routed to ${resolved.agentId} via @${alias} mention`);

--- a/src/infra/shared-profiles.test.ts
+++ b/src/infra/shared-profiles.test.ts
@@ -234,6 +234,10 @@ describe("resolveAgentFromAlias", () => {
     const result = resolveAgentFromAlias("anything", {});
     expect(result).toBeNull();
   });
+
+  it.each([undefined, null, ""])("contains malformed or missing aliases without throwing", (alias) => {
+    expect(resolveAgentFromAlias(alias, loadAgentProfiles())).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/infra/shared-profiles.ts
+++ b/src/infra/shared-profiles.ts
@@ -73,9 +73,10 @@ export function buildMentionPattern(profiles: Record<string, AgentProfile>): Reg
  * belongs to. Returns { agentId, label } or null if no match.
  */
 export function resolveAgentFromAlias(
-  alias: string,
+  alias: unknown,
   profiles: Record<string, AgentProfile>,
 ): { agentId: string; label: string } | null {
+  if (typeof alias !== "string" || alias.length === 0) return null;
   const lower = alias.toLowerCase();
   for (const [agentId, profile] of Object.entries(profiles)) {
     if (profile.mentionAliases.some(a => a.toLowerCase() === lower)) {

--- a/src/pipeline/webhook.test.ts
+++ b/src/pipeline/webhook.test.ts
@@ -804,6 +804,9 @@ describe("AgentSessionEvent.created full flow", () => {
   });
 
   it("routes to mentioned agent when @mention is present", async () => {
+    // Match the production pattern: /g makes String#match return full matches,
+    // not capture groups.
+    buildMentionPatternMock.mockReturnValue(/@(mal|mason|kaylee|eureka)/gi);
     resolveAgentFromAliasMock.mockReturnValue({ agentId: "kaylee", profile: { label: "Kaylee" } });
 
     const result = await postWebhook({
@@ -820,6 +823,7 @@ describe("AgentSessionEvent.created full flow", () => {
 
     expect(result.status).toBe(200);
     await new Promise((r) => setTimeout(r, 50));
+    expect(resolveAgentFromAliasMock).toHaveBeenCalledWith("kaylee", expect.any(Object));
     const infoCalls = (result.api.logger.info as any).mock.calls.map((c: any[]) => c[0]);
     expect(infoCalls.some((msg: string) => msg.includes("routed to kaylee"))).toBe(true);
   });
@@ -1048,6 +1052,8 @@ describe("AgentSessionEvent.prompted full flow", () => {
   });
 
   it("routes to mentioned agent in prompted follow-up", async () => {
+    // AgentSession.prompted uses the same global pattern as production.
+    buildMentionPatternMock.mockReturnValue(/@(mal|mason|kaylee|eureka)/gi);
     resolveAgentFromAliasMock.mockReturnValue({ agentId: "kaylee", profile: { label: "Kaylee" } });
 
     const result = await postWebhook({
@@ -1063,6 +1069,7 @@ describe("AgentSessionEvent.prompted full flow", () => {
 
     expect(result.status).toBe(200);
     await new Promise((r) => setTimeout(r, 50));
+    expect(resolveAgentFromAliasMock).toHaveBeenCalledWith("kaylee", expect.any(Object));
     const infoCalls = (result.api.logger.info as any).mock.calls.map((c: any[]) => c[0]);
     expect(infoCalls.some((msg: string) => msg.includes("routed to kaylee"))).toBe(true);
   });

--- a/src/pipeline/webhook.ts
+++ b/src/pipeline/webhook.ts
@@ -423,7 +423,10 @@ export async function handleLinearWebhook(
         mentionPattern.lastIndex = 0;
         const mentionMatch = text.match(mentionPattern);
         if (mentionMatch) {
-          const alias = mentionMatch[1];
+          // buildMentionPattern is global, so String#match returns full matches
+          // rather than capture groups. Use the first full mention consistently
+          // with both global and non-global patterns.
+          const alias = mentionMatch[0]?.replace(/^@/, "");
           const resolved = resolveAgentFromAlias(alias, profiles);
           if (resolved) {
             api.logger.info(`AgentSession routed to ${resolved.agentId} via @${alias} mention in ${text === userMessage ? "comment" : text === sessionPrompt ? "session prompt" : "promptContext"}`);
@@ -764,7 +767,8 @@ export async function handleLinearWebhook(
     if (promptedMentionPattern && userMessage) {
       const mentionMatch = userMessage.match(promptedMentionPattern);
       if (mentionMatch) {
-        const alias = mentionMatch[1];
+        // A global mention regex returns full matches only, not capture groups.
+        const alias = mentionMatch[0]?.replace(/^@/, "");
         const resolved = resolveAgentFromAlias(alias, promptedProfiles);
         if (resolved) {
           api.logger.info(`AgentSession prompted: routed to ${resolved.agentId} via @${alias} mention`);


### PR DESCRIPTION
Fixes #16

## Summary
- route AgentSession.created and AgentSession.prompted from the first full @mention, which works with the production global regex
- make malformed or missing aliases a safe no-op
- add global-regex single-mention regression coverage for both session paths

## Validation
- npx vitest run src/pipeline/webhook.test.ts --reporter=dot
- npx vitest run src/infra/shared-profiles.test.ts --reporter=verbose
- npm run typecheck
- npm run build

`npm test` was attempted but the pre-existing suite invokes git from a non-repository directory in this environment; CI is the authoritative whole-suite result.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/calltelemetry/codesmith/openclaw-linear-plugin/pr/19"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787713485&installation_model_id=428429&pr_number=19&repository=calltelemetry%2Fopenclaw-linear-plugin&return_to=https%3A%2F%2Fgithub.com%2Fcalltelemetry%2Fopenclaw-linear-plugin%2Fpull%2F19&signature=bbf2ad04be47feb405c82d809f37a393777f1ad71ff10c058d6d53c9ac48a7d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->